### PR TITLE
Teach file about glob!

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ Each plugin here is provided with a sample config file containing some documenta
 
 Here's our list of checks!
 
+## File
+
+Uses Python's `glob.glob` to look look for at least one file matching the provided `path`. You can control the success or failure of this check via `expect` using one of `present` or `absent`. For example if you use `expect: present` and the file does not exist, this check will fail. If you use `expect: absent` and the file is absent, it will emit ok!
+
+The service check and any emitted metrics are tagged with the `path`, `expected_status` and `actual_status`. It's check message will be `File %s that was expected to be %s is %s instead" % (path, expect, status)`.
+
+If this check *does* find a path that matches it will also emit a gauge `file.age_seconds` containing the age of the file in seconds, natch.
+
+```
+---
+init_config:
+
+instances:
+  # Puppet locks (these might turn stale):
+  - path: '/etc/stripe/facts/puppet_locked.txt'
+    expect: absent
+
+  # Package upgrades requiring reboots
+  - path: '/var/run/stripe/restart-required/*'
+    expect: absent
+```
+
 ## Resque
 
 Fetches metrics about processed jobs from Resque. It's pretty minimal, but we only needed it for a small thing.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Uses Python's `glob.glob` to look look for at least one file matching the provid
 
 The service check and any emitted metrics are tagged with the `path`, `expected_status` and `actual_status`. It's check message will be `File %s that was expected to be %s is %s instead" % (path, expect, status)`.
 
-If this check *does* find a path that matches it will also emit a gauge `file.age_seconds` containing the age of the file in seconds, natch.
+If this check *does* find a path that matches it will also emit a gauge `file.age_seconds` containing the age of the *oldest* file in seconds that matches the path.
 
 ```
 ---

--- a/checks.d/file.py
+++ b/checks.d/file.py
@@ -1,4 +1,5 @@
 import errno
+import glob
 import os
 import time
 
@@ -20,8 +21,14 @@ class FileCheck(AgentCheck):
 
     def stat_file(self, path):
         try:
-            statinfo = os.stat(path)
-            return self.STATUS_PRESENT, statinfo
+            files = glob.glob(path)
+            if len(files) > 0:
+                # We're only going to do something with the first file we find,
+                # I'm not sure how we'd stat multiple files and return them.
+                statinfo = os.stat(path[0])
+                return self.STATUS_PRESENT, statinfo
+            else:
+                return self.STATUS_ABSENT, []
         except OSError, e:
             if e.errno == errno.ENOENT:
                 return self.STATUS_ABSENT, []

--- a/tests/checks/integration/test_file.py
+++ b/tests/checks/integration/test_file.py
@@ -28,6 +28,38 @@ class TestFileUnit(AgentCheckTest):
         self.assertTrue(service_checks[0]['status'] == AgentCheck.OK)
         self.assert_tags(['expected_status:present', 'actual_status:present'], service_checks[0]['tags'])
 
+    def test_glob_present_success(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': '/tmp/*', 'expect': 'present'}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) == 1)
+        metric = metrics[0]
+        self.assertTrue(metric[2] > 0)
+        self.assert_tags(['expected_status:present', 'actual_status:present'], metric[3]['tags'])
+
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.OK)
+        self.assert_tags(['expected_status:present', 'actual_status:present'], service_checks[0]['tags'])
+
+    def test_glob_present_failure(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': '/doesntexist/*', 'expect': 'present'}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.CRITICAL)
+        self.assert_tags(['expected_status:present', 'actual_status:absent'], service_checks[0]['tags'])
 
     def test_absent_failure(self):
         conf = {

--- a/tests/checks/integration/test_file.py
+++ b/tests/checks/integration/test_file.py
@@ -1,3 +1,5 @@
+from tempfile import mkstemp, gettempdir
+
 # project
 from checks import AgentCheck
 from tests.checks.common import AgentCheckTest, load_check
@@ -29,10 +31,14 @@ class TestFileUnit(AgentCheckTest):
         self.assert_tags(['expected_status:present', 'actual_status:present'], service_checks[0]['tags'])
 
     def test_glob_present_success(self):
+        # Make some temporary files, just in case
+        mkstemp()
+        mkstemp()
+
         conf = {
             'init_config': {},
             'instances': [
-                {'path': '/tmp/*', 'expect': 'present'}
+                {'path': gettempdir() + "/*", 'expect': 'present'}
             ]
         }
         self.check = load_check('file', conf, {})


### PR DESCRIPTION
# What's this PR do?

Adjusts the `file` check to use Python's glob such that it supports Unix style pathname pattern expansion. 

I also documented in the readme!

# Motivation

In addition to single-file checks this lets this check also work with paths like `var/run/stripe/restart-required/*` such that any file being present will trigger the check when used with `expect: absent`.

# Notes

The `file.age_seconds` gauge is now returns the oldest files age in the event that there are > 1 files that match the pattern.

# Testing

Adding some new tests to cover this, made sure old tests are ok.

As for the age thing, I couldn't come up with a reasonable way to test this. Am open to ideas or just assuming it works ok. I'll do some testing in QA, of course.

r? @antifuchs 