### PR TITLE
Remove flappy tag from file.

### DIFF
--- a/checks.d/file.py
+++ b/checks.d/file.py
@@ -54,8 +54,7 @@ class FileCheck(AgentCheck):
 
         tags = [
             'expected_status:' + expect,
-            'path:' + path,
-            'actual_status:' + status,
+            'path:' + path
         ]
 
         # Emit a service check:


### PR DESCRIPTION
The `actual_status` tag is causing split-brain checks when it changes:

![screenshot 2016-09-07 08 22 11](https://cloud.githubusercontent.com/assets/45159/18322446/9114bdee-74e7-11e6-9856-7a36e822931f.png)

Since each unique combination of tags defines a check, it's causing monitors to go back to "OK" because the `actual_status` that differs from `expected_status` makes a check that has to then age out.

r? @antifuchs 