### PR TITLE
Add metric to outdated_packages check.

### DIFF
--- a/checks.d/outdated_packages.py
+++ b/checks.d/outdated_packages.py
@@ -100,6 +100,9 @@ class OutdatedPackagesCheck(AgentCheck):
             msg = "Package '{0}' does not specify version for release: {1}".format(package, codename)
 
         self.service_check('package.up_to_date', check_status, message=msg, tags=tags)
+        # We must emit a metric with the `package` tag if we want to use that tag in any
+        # dashboards because check tags are not included in template variables.
+        self.count('sys._outdated_packages.checked', 1, tags=tags)
 
         # Emit an event if the previous state is known & it's different:
         if self.has_different_status(package, status):


### PR DESCRIPTION
### What's this PR do?
Adds a metric to the `outdated_packages` check.

### Motivation
We can't use service check's tags in dashboards because service check tags are not included in the dropdowns. For that we need a metric tag. This basically emits a junk metric to ensure that's possible, since we'll get a metric for every package.

### Notes
Learned this from a support convo with Datadog:
> Indeed, such service check tags are not available currently for use in template variables.

### How To Deploy
Merge, then make a PR to bump the SHA in puppet and puppet the fleet.

r? @krstripe @rhwlo 
cc @andrew-d 