### PR TITLE
Add search metrics!

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ cache strip and the check.
 
 ## Splunk
 
-Collects metrics from a Splunk master about the status of a Splunk cluster.
+Collects metrics from a Splunk master about the status of a Splunk cluster. It assumes you are
+using Search Head Clustering and queries the SHC captain for search information.
 
 It emits these service checks:
   * `splunk.can_connect` when things break during fetching status
@@ -185,8 +186,6 @@ It emits these metrics:
   * `size_bytes` - The total size in bytes.
   * `total_excess_bucket_copies` - The total number of excess copies for all buckets.
   * `total_excess_searchable_copies` - The total number of excess searchable copies for all buckets.
-* `splunk.jobs`
-  * `present` all jobs the masters sees, tagged by `job_state`, `job_app` and `job_owner`
 * `splunk.peers` tagged by `peer_name`, and `site`
   * `bucket_count` - The number of buckets on this peer tagged additionally by `index`.
   * `bucket_status` - The number of buckets in a given status on this peer, tagged additionally by `bucket_status`.
@@ -196,7 +195,7 @@ It emits these metrics:
   * `primary_count_remote`  - The number of buckets for which the peer is primary that are not in its local site.
   * `replication_count` - The number of replications this peer is part of, as either source or target.
 * `splunk.searches`
-  * `in_progress` - In progress searches, tagged by `is_saved` and `search_owner`
+  * `in_progress` - In progress search gauge, tagged by `is_saved` and `search_owner`.
 
 You can configure it thusly:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ It emits these metrics:
   * `size_bytes` - The total size in bytes.
   * `total_excess_bucket_copies` - The total number of excess copies for all buckets.
   * `total_excess_searchable_copies` - The total number of excess searchable copies for all buckets.
+* `splunk.jobs`
+  * `present` all jobs the masters sees, tagged by `job_state`, `job_app` and `job_owner`
 * `splunk.peers` tagged by `peer_name`, and `site`
   * `bucket_count` - The number of buckets on this peer tagged additionally by `index`.
   * `bucket_status` - The number of buckets in a given status on this peer, tagged additionally by `bucket_status`.
@@ -193,6 +195,8 @@ It emits these metrics:
   * `primary_count` - The number of buckets for which the peer is primary in its local site, or the number of buckets that return search results from same site as the peer.
   * `primary_count_remote`  - The number of buckets for which the peer is primary that are not in its local site.
   * `replication_count` - The number of replications this peer is part of, as either source or target.
+* `splunk.searches`
+  * `in_progress` - In progress searches, tagged by `is_saved` and `search_owner`
 
 You can configure it thusly:
 ```yaml

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -44,7 +44,6 @@ class Splunk(AgentCheck):
             self.do_fixup_metrics(instance_tags, url, sessionkey, timeout)
 
         if self.is_captain(instance_tags, url, sessionkey, timeout):
-            self.do_job_metrics(instance_tags, url, sessionkey, timeout)
             self.do_search_metrics(instance_tags, url, sessionkey, timeout)
 
     def is_master(self, instance_tags, url, sessionkey, timeout):
@@ -62,23 +61,6 @@ class Splunk(AgentCheck):
             return False
         else:
             return True
-
-    def do_job_metrics(self, instance_tags, url, sessionkey, timeout):
-        response = self.get_json(url, '/services/shcluster/captain/jobs', instance_tags, sessionkey, timeout, params={'count': -1})
-
-        jobs = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: 0)))
-
-        for entry in response['entry']:
-            jobs[entry['content']['job_state']][entry['content']['search_app']][entry['content']['search_owner']] += 1
-
-        for job_state in jobs.keys():
-            for job_app in jobs[job_state].keys():
-                for job_owner in jobs[job_state][job_app].keys():
-                    self.gauge('splunk.jobs.present', jobs[job_state][job_app][job_owner], tags=instance_tags + [
-                        'job_state:{0}'.format(job_state),
-                        'job_app:{0}'.format(job_app),
-                        'job_owner:{0}'.format(job_owner)
-                    ])
 
     def do_search_metrics(self, instance_tags, url, sessionkey, timeout):
         response = self.get_json(url, '/services/search/jobs', instance_tags, sessionkey, timeout, params={'summarize': True, 'search': 'isDone=false'})

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -79,7 +79,7 @@ class Splunk(AgentCheck):
 
     def do_fixup_metrics(self, instance_tags, url, sessionkey, timeout):
         for level in self.FIXUP_LEVELS:
-            response = self.get_json(url, '/services/cluster/master/fixup', instance_tags, sessionkey, timeout, params={'level': level})
+            response = self.get_json(url, '/services/cluster/master/fixup', instance_tags, sessionkey, timeout, params={'level': level, 'count': -1})
 
             # Accumulate a count by index so we can emit a gauge.
             index_tasks = defaultdict(lambda x: 0)
@@ -94,7 +94,7 @@ class Splunk(AgentCheck):
                 ])
 
     def do_peer_metrics(self, instance_tags, url, sessionkey, timeout):
-        response = self.get_json(url, '/services/cluster/master/peers', instance_tags, sessionkey, timeout)
+        response = self.get_json(url, '/services/cluster/master/peers', instance_tags, sessionkey, timeout, params={'count': -1})
         peer_statuses = defaultdict(lambda x: 0)
         for peer in response['entry']:
             host = peer['content']['label']
@@ -136,7 +136,7 @@ class Splunk(AgentCheck):
 
 
     def do_index_metrics(self, instance_tags, url, sessionkey, timeout):
-        response = self.get_json(url, '/services/cluster/master/indexes', instance_tags, sessionkey, timeout)
+        response = self.get_json(url, '/services/cluster/master/indexes', instance_tags, sessionkey, timeout, params={'count': -1})
         for index in response['entry']:
             name = index['name']
 

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -1,7 +1,6 @@
 # stdlib
 import time
 from collections import defaultdict
-from urllib import quote_plus
 from urlparse import urljoin
 from xml.dom import minidom
 


### PR DESCRIPTION
### What's this PR do?
Adds "search" metrics from the searchhead.

### Motivation
We want to know what's being run on the cluster!



### Notes
* This has been tested in prod. Works!
* Please look at the metric names (gauges). Do you have any better ideas, esp for jobs?
* Should we just exclude "completed" searches? I did in the search, but not the jobs.
* Completed jobs have duration and other performance metrics which might be worth looking at, but I argue that an avg or percentile of timing would be kinda worthless unless normalized by duration or # records…
* We can skip any of the above and keep iterating too. :)

r? @krstripe
