### PR TITLE
Add new checks for slapd

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,45 @@ Inspects the Redis storage for a Resque instance and ouputs some metrics:
 * `resque.worker_count` - number of workers (gauge)
 
 
+## Slapd (OpenLDAP's Stand-alone LDAP Daemon)
+
+This check queries and surfaces statistics from the [`monitor`
+backend][ldapmon] of a running `slapd` instance.  It will emit the following
+metrics:
+
+* `slapd.connect_time` - time taken to connect to the server (histogram)
+* `slapd.connections.total` - total number of connections (monotonic_count)
+* `slapd.connections.current` - current number of connections (gauge)
+* `slapd.statistics.bytes_total` - total bytes sent (monotonic_count)
+* `slapd.statistics.entries_total` - total entries sent (monotonic_count)
+* `slapd.threads.active` - number of active threads (gauge)
+* `slapd.threads.open` - number of open threads (gauge)
+* `slapd.threads.pending` - number of pending threads (gauge)
+* `slapd.threads.starting` - number of threads being started (gauge)
+* `slapd.waiters.read` - the number of clients waiting to read (gauge)
+* `slapd.waiters.write` - the number of clients waiting to write (gauge)
+
+In addition, the check will emit a service check (`slapd.can_connect`) that
+indicates whether it was able to successfully connect to the LDAP server.
+
+[ldapmon]: http://www.openldap.org/doc/admin24/monitoringslapd.html
+
+### Slapd Configuration
+
+To enable the `monitor` backend, you can add the following lines to
+`slapd.conf`:
+
+```
+moduleload back_monitor
+database monitor
+access to dn="cn=monitor"
+  by peername=127.0.0.1 read
+  by * none
+```
+
+This allows only clients on the local machine to access the backend, since it
+may contain potentially-sensitive information.
+
 ## Storm REST API
 
 This check comes in two parts: One is a cronjob-able script in

--- a/checks.d/slapd.py
+++ b/checks.d/slapd.py
@@ -1,0 +1,194 @@
+# stdlib
+import time
+import warnings
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+# 3rd party
+import ldap
+
+# project
+from checks import AgentCheck
+
+
+class Slapd(AgentCheck):
+
+    CONNECT_CHECK_NAME = 'slapd.can_connect'
+
+    def check(self, instance):
+        if 'uri' not in instance:
+            raise Exception('slapd instance missing "uri" value.')
+
+        # Load values from instance configuration
+        instance_tags = instance.get('tags', []) + ['instance:{0}'.format(instance['uri'])]
+
+        # Connect to the LDAP server, and also update our service check.
+        try:
+            start_time = time.time()
+            conn = self.connect_to_server(instance)
+            elapsed_time = time.time() - start_time
+            self.histogram('slapd.connect_time', int(elapsed_time))
+        except ldap.LDAPError:
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message="Could not connect to LDAP server",
+                tags=[])
+            return
+        else:
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.OK, tags=[])
+
+        # Connection info
+        self.monotonic_count('slapd.connections.total',
+                self.fetch_metric(conn, 'cn=Total,cn=Connections,cn=monitor'),
+                tags=instance_tags)
+        self.gauge('slapd.connections.current',
+                self.fetch_metric(conn, 'cn=Current,cn=Connections,cn=monitor'),
+                tags=instance_tags)
+
+        # Statistics
+        self.monotonic_count('slapd.statistics.bytes_total',
+                self.fetch_metric(conn, 'cn=Bytes,cn=Statistics,cn=monitor'),
+                tags=instance_tags)
+        self.monotonic_count('slapd.statistics.entries_total',
+                self.fetch_metric(conn, 'cn=Entries,cn=Statistics,cn=monitor'),
+                tags=instance_tags)
+
+        # Thread info
+        self.gauge('slapd.threads.active',
+                self.fetch_metric(conn, 'cn=Active,cn=Threads,cn=monitor'),
+                tags=instance_tags)
+        self.gauge('slapd.threads.open',
+                self.fetch_metric(conn, 'cn=Open,cn=Threads,cn=monitor'),
+                tags=instance_tags)
+        self.gauge('slapd.threads.pending',
+                self.fetch_metric(conn, 'cn=Pending,cn=Threads,cn=monitor'),
+                tags=instance_tags)
+        self.gauge('slapd.threads.starting',
+                self.fetch_metric(conn, 'cn=Starting,cn=Threads,cn=monitor'),
+                tags=instance_tags)
+
+        # Waiters info
+        self.gauge('slapd.waiters.read',
+                self.fetch_metric(conn, 'cn=Read,cn=Waiters,cn=monitor'),
+                tags=instance_tags)
+        self.gauge('slapd.waiters.write',
+                self.fetch_metric(conn, 'cn=Write,cn=Waiters,cn=monitor'),
+                tags=instance_tags)
+
+    def fetch_metric(self, conn, bind, type=int):
+        self.log.debug("Running bind: {1}", bind)
+
+        try:
+            res = conn.search_s(bind, ldap.SCOPE_SUBTREE, '(objectClass=*)', ['*', '+'])
+            if len(res) == 0:
+                self.log.warn("No results for bind: {0}", bind)
+                return None
+        except ldap.NO_SUCH_OBJECT:
+            self.log.warn("No such object for bind: {0}", bind)
+            return None
+        except ldap.LDAPError as e:
+            self.log.error("Unexpected error for bind {0}:", bind, e)
+            return None
+
+        # Take first result from the server
+        _, attrs = res[0]
+
+        obj_class = attrs['structuralObjectClass'][0]
+        if obj_class == 'monitoredObject':
+            value_field = 'monitoredInfo'
+        elif obj_class == 'monitorCounterObject':
+            value_field = 'monitorCounter'
+        else:
+            self.log.error("Unknown type of metric: {0}", obj_class)
+            return None
+
+        try:
+            # Since a single result can contain multiple values, we also take
+            # the first element in the list.
+            value = attrs[value_field][0]
+        except (KeyError, IndexError):
+            self.log.error("Unable to extract value from bind: {0}", bind)
+            return None
+
+        # Try to convert by passing the value to the type of the metric.
+        converted = value
+        if type is not None:
+            try:
+                converted = type(value)
+            except (ValueError, TypeError):
+                self.log.warn('Unable to convert metric for bind {0}: {1} cannot be converted to {2}',
+                    bind,
+                    value,
+                    type.__name__
+                )
+
+        self.log.debug("Finished with bind: {0}", bind)
+        return converted
+
+    def connect_to_server(self, instance):
+        uri_info = urlparse(instance['uri'])
+        use_ldaps = uri_info.scheme == 'ldaps'
+
+        l = ldap.initialize(instance['uri'])
+        options = [
+            ('network_timeout', ldap.OPT_NETWORK_TIMEOUT, int),
+            ('protocol_version', ldap.OPT_PROTOCOL_VERSION, int),
+        ]
+
+        tls_options = [
+            ('tls_cacert', ldap.OPT_X_TLS_CACERTFILE, str),
+            ('tls_certfile', ldap.OPT_X_TLS_CERTFILE, str),
+            ('tls_keyfile', ldap.OPT_X_TLS_KEYFILE, str),
+        ]
+
+        # Helper function that actually sets options on the connection.
+        def set_options(defs):
+            for name, ldapopt, ty in defs:
+                val = instance.get(name)
+                if not val:
+                    continue
+
+                if not isinstance(val, ty):
+                    raise TypeError('slapd instance has key "%s" of type "%s", but expected type "%s"' % (
+                        name,
+                        type(val),
+                        ty
+                    ))
+
+                l.set_option(ldapopt, val)
+
+        # Always set generic options
+        l.set_option(ldap.OPT_REFERRALS, 0)
+        set_options(options)
+
+        # Only set TLS options if necessary
+        if instance.get('starttls', False) or use_ldaps:
+            set_options(tls_options)
+
+            # If we're connecting using LDAPS, we demand TLS.
+            l.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND if use_ldaps else ldap.OPT_X_TLS_NEVER)
+
+            # Set up cert verification.
+            l.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,
+                    ldap.OPT_X_TLS_DEMAND if instance.get('verify_cert') else ldap.OPT_X_TLS_ALLOW)
+
+            # Force the creation of a new TLS context.  This must be the last TLS option.
+            l.set_option(ldap.OPT_X_TLS_NEWCTX, 0) 
+
+        # Once we're done with all options, perform STARTTLS (as long as this
+        # isn't a LDAPS connection).
+        if instance.get('starttls', False):
+            if use_ldaps:
+                warnings.warn("Can't use STARTTLS since connection is already using SSL (LDAPS)")
+            else:
+                l.start_tls_s()
+
+        # Perform either simple or anonymous bind.
+        password = instance.get('bind_password')
+        if password:
+            l.simple_bind_s(instance.get('bind_dn'), password)
+        else:
+            l.simple_bind_s()
+
+        return l

--- a/conf.d/slapd.yaml.example
+++ b/conf.d/slapd.yaml.example
@@ -1,0 +1,14 @@
+---
+instances:
+  - uri: ldaps://localhost
+    bind_dn: value                  # DN used to initially bind the connection
+    bind_password: password         # Password for the initial bind; if not
+                                    # set, perform an anonymous bind that
+                                    # ignores `bind_dn`
+    network_timeout: 10             # Timeout for connections
+    protocol_version: 3             # Protocol version (2 or 3)
+    starttls: false                 # Use STARTTLS (default: false)
+    tls_cacert: /path/to/cacert     # Server CA certificate path
+    tls_certfile: /path/to/cert     # Client certificate path
+    tls_keyfile: /path/to/keyfile   # Client certificate key file path
+    verify_cert: true               # If true, will enforce and verify TLS


### PR DESCRIPTION
This adds some initial metrics for `slapd` that come from the [monitor backend](http://www.openldap.org/devel/admin/monitoringslapd.html).  I still haven't quite got this working yet, since we need to have `python-ldap` installed so DataDog's python knows about it.  I've been testing by just symlinking the system version into the right place (since we already have it installed on the system for `nsscache`).