### PR TITLE
Fix peer statuses and add search head statuses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ It emits these metrics:
   * `primary_count` - The number of buckets for which the peer is primary in its local site, or the number of buckets that return search results from same site as the peer.
   * `primary_count_remote`  - The number of buckets for which the peer is primary that are not in its local site.
   * `replication_count` - The number of replications this peer is part of, as either source or target.
+* `splunk.search_cluster`
+  * `captains` - The count of captains tagged by `site`. This can be used to ensure a captain and detect splitbrain
+  * `member_statuses` - The number of members in the search cluster tagged by `status` and `site`.
 * `splunk.searches`
   * `in_progress` - In progress search gauge, tagged by `is_saved` and `search_owner`.
 

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -69,13 +69,18 @@ class Splunk(AgentCheck):
 
         members = defaultdict(lambda: defaultdict(lambda: 0))
 
+        captains = defaultdict(lambda: 0)
         for entry in response['entry']:
             members[entry['content']['site']][entry['content']['status']] += 1
 
+            # Count the # of captains so we can detect splitbrains
             if entry['content']['is_captain']:
-                self.gauge('splunk.search_cluster.captains', 1, tags=instance_tags + [
-                    'site:{0}'.format(entry['content']['site'])
-                ])
+                captains[entry['content']['site']] += 1
+
+        for site, count in captains.items():
+            self.gauge('splunk.search_cluster.captains', count, tags=instance_tags + [
+                'site:{0}'.format(site)
+            ])
 
         for member_site in members.keys():
             for status, count in members[member_site].items():

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -46,6 +46,7 @@ class Splunk(AgentCheck):
 
         if self.is_captain(instance_tags, url, sessionkey, timeout):
             self.do_search_metrics(instance_tags, url, sessionkey, timeout)
+            self.do_shmember_metrics(instance_tags, url, sessionkey, timeout)
 
     def is_master(self, instance_tags, url, sessionkey, timeout):
         try:
@@ -62,6 +63,26 @@ class Splunk(AgentCheck):
             return False
         else:
             return True
+
+    def do_shmember_metrics(self, instance_tags, url, sessionkey, timeout):
+        response = self.get_json(url, '/services/shcluster/captain/members', instance_tags, sessionkey, timeout, params={'count': -1})
+
+        members = defaultdict(lambda: defaultdict(lambda: 0))
+
+        for entry in response['entry']:
+            members[entry['content']['site']][entry['content']['status']] += 1
+
+            if entry['content']['is_captain']:
+                self.gauge('splunk.search_cluster.captains', 1, tags=instance_tags + [
+                    'site:{0}'.format(entry['content']['site'])
+                ])
+
+        for member_site in members.keys():
+            for status, count in members[member_site].items():
+                self.gauge('splunk.search_cluster.member_statuses', count, tags=instance_tags + [
+                    'site:{0}'.format(member_site),
+                    'status:{0}'.format(status)
+                ])
 
     def do_search_metrics(self, instance_tags, url, sessionkey, timeout):
         response = self.get_json(url, '/services/search/jobs', instance_tags, sessionkey, timeout, params={'summarize': True, 'search': 'isDone=false'})
@@ -117,7 +138,7 @@ class Splunk(AgentCheck):
 
     def do_peer_metrics(self, instance_tags, url, sessionkey, timeout):
         response = self.get_json(url, '/services/cluster/master/peers', instance_tags, sessionkey, timeout, params={'count': -1})
-        peer_statuses = defaultdict(lambda x: 0)
+        peer_statuses = defaultdict(lambda: defaultdict(lambda: 0))
         for peer in response['entry']:
             host = peer['content']['label']
             site = peer['content']['site']
@@ -126,6 +147,8 @@ class Splunk(AgentCheck):
                 'peer_name:{0}'.format(host),
                 'site:{0}'.format(site),
             ]
+
+            peer_statuses[site][peer['content']['status']] += 1
 
             searchable = peer['content']['is_searchable']
             if not searchable:
@@ -151,11 +174,12 @@ class Splunk(AgentCheck):
 
         # This is a synthetic metric to make it easier to count the number of peers
         # in whatever status.
-        for status, count in peer_statuses.items():
-            self.gauge('splunk.peers.peers_present', count, tags=tags + [
-                'status:{0}'.format(status)
-            ])
-
+        for site in peer_statuses.keys():
+            for status, count in peer_statuses[site].items():
+                self.gauge('splunk.peers.peers_present', count, tags=tags + [
+                    'status:{0}'.format(status),
+                    'site:{0}'.format(site)
+                ])
 
     def do_index_metrics(self, instance_tags, url, sessionkey, timeout):
         response = self.get_json(url, '/services/cluster/master/indexes', instance_tags, sessionkey, timeout, params={'count': -1})


### PR DESCRIPTION
### What's this PR do?
Fixes a bug in indexer peer metrics — namely that they didn't exist — and adds statuses of each member of the search cluster. Lastly adds a gauge for the # of captains.

### Motivation
* Detect splitbrain of search captains
* Properly track statuses of indexer peers (oops!)
* Add count of search heads so we can see the state of that cluster too

r? @krstripe 

