### PR TITLE
added a lever to only use part of a task_id

### DIFF
--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -14,7 +14,13 @@ import unittest
 # project
 from checks import AgentCheck
 from config import get_checksd_path
-from util import get_hostname, get_os
+
+try:
+    from util import get_hostname, get_os
+except ImportError:
+    from utils.hostname import get_hostname
+    from utils.platform import get_os
+
 from utils.debug import get_check  # noqa -  FIXME 5.5.0 AgentCheck tests should not use this
 
 log = logging.getLogger('tests')


### PR DESCRIPTION
This completely optional lever can be used to, instead of using an entire task_id to look for tags, use a smaller subset of it, which is useful if task names have some variability to them.

Without the new parameter in the config, we should still get the old behavior