### PR TITLE
added conditional imports for different versions

### DIFF
--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -14,7 +14,13 @@ import unittest
 # project
 from checks import AgentCheck
 from config import get_checksd_path
-from util import get_hostname, get_os
+
+try:
+    from util import get_hostname, get_os
+except ImportError:
+    from utils.hostname import get_hostname
+    from utils.platform import get_os
+
 from utils.debug import get_check  # noqa -  FIXME 5.5.0 AgentCheck tests should not use this
 
 log = logging.getLogger('tests')


### PR DESCRIPTION
I was having trouble running tests using the makefile + docker image because python couldn't find the get_hostname function

@gphat told me the imports that I needed instead, so I added a conditional to make it work on both versions

I submit it as a PR because if I need this to get the tests to run, chances are other people will too.