### PR TITLE
Fix absent resque keys

### DIFF
--- a/checks.d/resque.py
+++ b/checks.d/resque.py
@@ -25,12 +25,12 @@ class ResqueVMCheck(AgentCheck):
 
         # Get scalars
         for key, name in self.SCALAR_KEYS.iteritems():
-            value = conn.get(key)
+            value = conn.get(key) or 0
             self.monotonic_count(name, int(value))
 
         # Get set cardinality
         for key, name in self.CARD_KEYS.iteritems():
-            value = conn.scard(key)
+            value = conn.scard(key) or 0
             self.gauge(name, int(value))
 
         del conn


### PR DESCRIPTION
If there is no key present, this integration dies on trying to cast None to an int
Fix this by defaulting to 0

R? @gphat 