### PR TITLE
Move the service check to the auth section to prevent weirdness.

### DIFF
--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -35,8 +35,28 @@ class Splunk(AgentCheck):
         timeout = float(instance.get('timeout', default_timeout))
 
         # Grab a session key for authentication
-        r = requests.post(urljoin(url, '/services/auth/login'), verify=False, timeout=timeout, data={'username':username, 'password':password})
-        sessionkey = minidom.parseString(r.text).getElementsByTagName('sessionKey')[0].childNodes[0].nodeValue
+        try:
+            r = requests.post(urljoin(url, '/services/auth/login'), verify=False, timeout=timeout, data={'username':username, 'password':password})
+            sessionkey = minidom.parseString(r.text).getElementsByTagName('sessionKey')[0].childNodes[0].nodeValue
+        except requests.exceptions.Timeout:
+            # If there's a timeout
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message='Timed out after {0} seconds.'.format(timeout),
+                tags = instance_tags)
+            raise Exception("Timeout when hitting URL")
+
+        except requests.exceptions.HTTPError:
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message='Returned a status of {0}'.format(r.status_code),
+                tags = instance_tags)
+            raise Exception("Got {0} when hitting URL".format(r.status_code))
+
+        else:
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.OK,
+                tags = instance_tags
+            )
+
+        self.get_json(url, '/services/server/info', instance_tags, sessionkey, timeout, True)
 
         if self.is_master(instance_tags, url, sessionkey, timeout):
             self.do_index_metrics(instance_tags, url, sessionkey, timeout)
@@ -270,19 +290,9 @@ class Splunk(AgentCheck):
             self.histogram('splunk.stats_fetch_duration_seconds', int(elapsed_time), tags = [ 'path:{0}'.format(path) ])
         except requests.exceptions.Timeout:
             # If there's a timeout
-            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
-                message='Timed out after {0} seconds.'.format(timeout),
-                tags = instance_tags)
             raise Exception("Timeout when hitting URL")
 
         except requests.exceptions.HTTPError:
-            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
-                message='Returned a status of {0}'.format(r.status_code),
-                tags = instance_tags)
             raise Exception("Got {0} when hitting URL".format(r.status_code))
 
-        else:
-            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.OK,
-                tags = instance_tags
-            )
         return r.json()

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -56,8 +56,6 @@ class Splunk(AgentCheck):
                 tags = instance_tags
             )
 
-        self.get_json(url, '/services/server/info', instance_tags, sessionkey, timeout, True)
-
         if self.is_master(instance_tags, url, sessionkey, timeout):
             self.do_index_metrics(instance_tags, url, sessionkey, timeout)
             self.do_peer_metrics(instance_tags, url, sessionkey, timeout)


### PR DESCRIPTION
### What's this PR do?
Only emits a service check for the authentication step of the check.

### Motivation
As it stands, we make a number of API calls that will fail. We indiscriminately fire off requests for both search heads and masters relying on the status codes to tell us if they are valid. This causes us to emit a bunch of OK and !OK checks that make the service check useless.

By moving this to one check we get consistency!

### How To Deploy
* Merge!
* Make a PR for Puppet ;P

### How to Rollback
Revert, merge, repeat `How To Deploy`

r? @krisreeves-stripe 
