### PR TITLE
Add openvpn check to limit per-user connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ instances:
     command: "/usr/lib/nagios/plugins/check_falafel -l 1234"
 ```
 
+## OpenVPN
+
+
+The OpenVPN check counts the number of active VPN connections per user. Combined with a Datadog monitor, it ensures that the same user isn't logged in mtoo many times (e.g., multiple, sustained VPN connections for the same user is indicative of a laptop compromise).
+
+Each VPN is accessible over both TCP and UDP, and is available to both privileged (Stripe employees) and unprivileged users (vendors). The unique combination of these is considered a VPN "level", and OpenVPN emits a status file every 10 seconds for each level to indicate the currently-active connections. When a user disconnects (e.g. if their Internet connection drops out) or if their IP address/port changes, they may appear in the status file multiple times. This is fine, as long as the number of connections per user drops down to 1 within a minute or so.
+
+The status file also contains useful information such as the IP (which can be used for geolookups), the connection duration (which can be used to ensure that the VPN is online and that it isn't cycling users), and the number of bytes sent/received (which could be used to detect erratic behavior).
+
+
+
 ## Outdated Packages
 
 This check verifies that the given packages are not outdated (currently, only

--- a/checks.d/openvpn.py
+++ b/checks.d/openvpn.py
@@ -1,0 +1,42 @@
+import csv
+from collections import defaultdict
+
+# project
+from checks import AgentCheck
+
+
+# Each user really should only have one active connection
+# but empirically, a user can have 3 connections within a 10-second
+# interval without it being the sign of a problem (probably 
+# due to reconnections)
+USER_MAX_CONNECTIONS = 4
+
+class Splunk(AgentCheck):
+    def check(self, instance):
+        filename = instance['path']
+        self.parse_status_file(filename)
+
+
+    def parse_status_file(self, filename):
+        with open(filename) as csvfile:
+            reader = csv.reader(csvfile, delimiter='\t')
+            users = defaultdict(int)
+            for row in reader:
+                if len(row) < 2:
+                    continue 
+                if row[0] != "CLIENT_LIST":
+                    continue
+                #TODO parse routing table as well
+                username = row[1]
+                users[username] += 1
+
+            for user, num in users.iteritems():
+                if num > USER_MAX_CONNECTIONS:
+                    raise Exception('User {0} connected too many times: {1}'.format(user, str(num)))
+
+
+
+
+
+
+

--- a/checks.d/openvpn.py
+++ b/checks.d/openvpn.py
@@ -1,23 +1,35 @@
 import csv
+import os
+import datetime
 from collections import defaultdict
 
 # project
 from checks import AgentCheck
 
+# 15 seconds appears to be too short of an interval
+FILE_REFRESH_SECONDS = 25
 
-# Each user really should only have one active connection
-# but empirically, a user can have 3 connections within a 10-second
-# interval without it being the sign of a problem (probably 
-# due to reconnections)
-USER_MAX_CONNECTIONS = 4
-
-class Splunk(AgentCheck):
+class OpenVPN(AgentCheck):
     def check(self, instance):
+        # path and vpn_name should always be present
         filename = instance['path']
-        self.parse_status_file(filename)
+        vpn_name = instance['vpn_name']
+        instance_tags = instance['tags']
+        self.parse_status_file(filename, instance_tags)
 
+        if not os.path.isfile(filename):
+            self.service_check('openvpn.status.is_running', AgentCheck.CRITICAL,
+                    message='VPN level {0} is not running'.format(vpn_name),
+                    tags = instance_tags)
 
-    def parse_status_file(self, filename):
+        mtimestamp = os.path.getmtime(filename)
+        now = int(datetime.datetime.now().strftime("%s"))
+        if now - mtimestamp > FILE_REFRESH_SECONDS:
+            self.service_check('openvpn.status.is_running', AgentCheck.CRITICAL,
+                    message='VPN level {0} is not running'.format(vpn_name),
+                    tags = instance_tags)
+
+    def parse_status_file(self, filename, instance_tags):
         with open(filename) as csvfile:
             reader = csv.reader(csvfile, delimiter='\t')
             users = defaultdict(int)
@@ -31,12 +43,6 @@ class Splunk(AgentCheck):
                 users[username] += 1
 
             for user, num in users.iteritems():
-                if num > USER_MAX_CONNECTIONS:
-                    raise Exception('User {0} connected too many times: {1}'.format(user, str(num)))
-
-
-
-
-
+                self.gauge('openvpn.users.connections', num, tags=instance_tags + ['common_name:{0}'.format(user)])
 
 

--- a/conf.d/openvpn.yaml
+++ b/conf.d/openvpn.yaml
@@ -1,24 +1,30 @@
-# init_config:
-# # Not required for this check
-#
-# instances:
-#  - path: '/var/run/reboot-required'
-#    expected: absent
-#  - path: '/etc/passwd'
-#    expected: present
-
 init_config:
   # Not required for this check
 
 instances:
   - path: '/pay/log/openvpn-tcp-privileged.status'
-    expected: present
+    vpn_name: openvpn-tcp-privileged
+    tags:
+      - 'transport:tcp'
+      - 'access_level:privileged'
   - path: '/pay/log/openvpn-tcp-unprivileged.status'
-    expected: present
+    vpn_name: openvpn-tcp-unprivileged
+    tags:
+      - 'transport:tcp'
+      - 'access_level:unprivileged'
   - path: '/pay/log/openvpn-udp-dashboard.status'
-    expected: present
+    vpn_name: openvpn-udp-dashboard
+    tags:
+      - 'transport:udp'
+      - 'access_level:dashboard'
   - path: '/pay/log/openvpn-udp-privileged.status'
-    expected: present
+    vpn_name: openvpn-udp-privileged
+    tags:
+      - 'transport:udp'
+      - 'access_level:privileged'
   - path: '/pay/log/openvpn-udp-unprivileged.status'
-    expected: present
+    vpn_name: openvpn-udp-unprivileged
+    tags:
+      - 'transport:udp'
+      - 'access_level:unprivileged'
 

--- a/conf.d/openvpn.yaml
+++ b/conf.d/openvpn.yaml
@@ -1,0 +1,24 @@
+# init_config:
+# # Not required for this check
+#
+# instances:
+#  - path: '/var/run/reboot-required'
+#    expected: absent
+#  - path: '/etc/passwd'
+#    expected: present
+
+init_config:
+  # Not required for this check
+
+instances:
+  - path: '/pay/log/openvpn-tcp-privileged.status'
+    expected: present
+  - path: '/pay/log/openvpn-tcp-unprivileged.status'
+    expected: present
+  - path: '/pay/log/openvpn-udp-dashboard.status'
+    expected: present
+  - path: '/pay/log/openvpn-udp-privileged.status'
+    expected: present
+  - path: '/pay/log/openvpn-udp-unprivileged.status'
+    expected: present
+


### PR DESCRIPTION
First pass/WIP. This checks that a user can have no more than 3 active VPN connections simultaneously.


I chose the number 3 through a very rigorous process by which, while testing it manually, I noticed that occasionally a user would be listed up to three times (due to connection restarts), and that this would be resolved the next time the file was regenerated. 



r? @gphat 