### PR TITLE
Send IP address and inferred subnet in OpenVPN check

### DIFF
--- a/checks.d/openvpn.py
+++ b/checks.d/openvpn.py
@@ -2,10 +2,27 @@ import csv
 import os
 import datetime
 from collections import defaultdict
+from collections import Counter
+import re
 
 # project
 from checks import AgentCheck
 
+IPV4_REGEX = re.compile('^((?:[0-9]{1,3}\.){3}[0-9]{1,3})(:\d+)*$')
+
+# Removes the port from an IP address
+# Currently assumes that the address is
+# an IPv4 address
+def strip_port(ipv4_address):
+    matches = IPV4_REGEX.match(ipv4_address)
+    if matches is not None:
+        return matches.group(1)
+    return None
+
+# Infers the /24 of the address.
+# e.g. 192.168.1.1 will return 192.168.1.0/24
+def infer_subnet_24(ipv4_address):
+    return '.'.join(ipv4_address.split('.', 3)[0:3] + ['0']) + '/24'
 
 class OpenVPN(AgentCheck):
 
@@ -37,17 +54,26 @@ class OpenVPN(AgentCheck):
     def parse_status_file(self, filename, instance_tags):
         with open(filename) as csvfile:
             reader = csv.reader(csvfile, delimiter='\t')
-            users = defaultdict(int)
+            users = defaultdict(list)
             for row in reader:
-                if len(row) < 2:
-                    continue 
+                if len(row) < 3:
+                    continue
                 if row[0] != "CLIENT_LIST":
                     continue
-                #TODO parse routing table as well
+                #TODO parse ROUTING_TABLE entries as well
                 username = row[1]
-                users[username] += 1
 
-            for user, num in users.iteritems():
-                self.gauge('openvpn.users.connections', num, tags=instance_tags + ['common_name:{0}'.format(user)])
+                # we don't care if the user's port changed
+                real_address = strip_port(row[2])
 
+                users[username].append(real_address)
 
+            for user, addresses in users.iteritems():
+                c = Counter(addresses)
+                for address in c:
+                    count = c[address]
+                    subnet = infer_subnet_24(address)
+                    self.gauge('openvpn.users.connections', count, tags=instance_tags + ['common_name:{0}'.format(user),
+                        'ip:{0}'.format(address),
+                        'subnet:{0}'.format(subnet),
+                        ])


### PR DESCRIPTION
This sends the IP address and the inferred `/24` of the IP address along with each connected user in the OpenVPN check.


Tag cardinality is pretty tightly scoped here due to number of active connections and the IP ranges we care about (and the time intervals). And given that we're adding the IP address, including the `/24` doesn't change the tag carnality (it just makes it easier to use in Datadog).

Tested manually on one of the VPN boxes.

r? @cory-stripe || @gphat 