### PR TITLE
Add gauge to track distinct IP addresses per user

### DIFF
--- a/checks.d/openvpn.py
+++ b/checks.d/openvpn.py
@@ -70,6 +70,7 @@ class OpenVPN(AgentCheck):
 
             for user, addresses in users.iteritems():
                 c = Counter(addresses)
+                self.gauge('openvpn.users.connections.distinct_ip4', len(c), tags=instance_tags + ['common_name:{0}'.format(user)])
                 for address in c:
                     count = c[address]
                     subnet = infer_subnet_24(address)


### PR DESCRIPTION
This gives us the best of both worlds - we can see the number of distinct IP addresses connected for each user, but we can also track the individual IPs connected for each user as well.




r? @cory-stripe || @gphat 