### PR TITLE
Fix percentile 100th metric on NSQ latency

### DIFF
--- a/checks.d/nsq.py
+++ b/checks.d/nsq.py
@@ -112,7 +112,10 @@ class NSQ(AgentCheck):
                         # so we'll do that by splitting on the . and left-justifying up to
                         # 2 spaces, filling with 0. Note that `ljust` returns the whole strong
                         # if it is >= the length. This converts 0.5 in to '50' and .9999 in to '9999'
-                        quantile = str(latency['quantile']).split(".")[1].ljust(2, "0")
+                        if latency['quantile'] == 1:
+                            quantile = '100'
+                        else:
+                            quantile = str(latency['quantile']).split(".")[1].ljust(2, "0")
                         self.gauge('nsq.topic.channel.e2e_processing_latency.p' + quantile, latency['value'], tags=channel_tags)
 
     def get_json(self, url, timeout):


### PR DESCRIPTION
When 100th percentile value is used on `--e2e-processing-latency-percentile` option, the `nsq.py` script will fail to parse the JSON output throwing the following error:

```
2017-01-25 15:38:58 UTC | ERROR | dd.collector | checks.nsq(__init__.py:784) | Check 'nsq' instance #0 failed
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks/__init__.py", line 767, in run
    self.check(copy.deepcopy(instance))
  File "/etc/dd-agent/checks.d/nsq.py", line 115, in check
    quantile = str(latency['quantile']).split(".")[1].ljust(2, "0")
IndexError: list index out of range
```

It fails because it expects a `.` character on the quantile field, this does not happen on 100th percentile.

For example, `--e2e-processing-latency-percentile=1.0,0.99,0.95` generates the following JSON output:

```json
                "e2e_processing_latency": {
                    "count": 19954,
                    "percentiles": [
                        {
                            "quantile": 1,
                            "value": 28398404.0
                        },
                        {
                            "quantile": 0.99,
                            "value": 28398404.0
                        },
                        {
                            "quantile": 0.95,
                            "value": 18972390.0
                        }
                    ]
                },
```