### PR TITLE
Introduce a check on the existence of objects in S3

### DIFF
--- a/checks.d/s3_object_exists.py
+++ b/checks.d/s3_object_exists.py
@@ -15,6 +15,13 @@ from checks import AgentCheck
 
 
 class S3ObjectExists(AgentCheck):
+    """
+    Ensure that one or more S3 objects with a URL prefix exists by that time
+    `sla_seconds` have passed since the start of the day.
+
+    This is particularly helpful for determining if daily-generated files
+    have been created on time, and to alert if they are missing.
+    """
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
@@ -77,7 +84,7 @@ class S3ObjectExists(AgentCheck):
 
         client = self.get_client()
         objects = []
-        list_args = {"Bucket": uri.netloc, "Prefix": uri.path}
+        list_args = {"Bucket": uri.netloc, "Prefix": uri.path.lstrip('/')}
         while True:
             resp = client.list_objects(**list_args)
             objects.extend(resp['Contents'])

--- a/checks.d/s3_object_exists.py
+++ b/checks.d/s3_object_exists.py
@@ -1,0 +1,114 @@
+# stdlib
+import datetime
+import json
+import os
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+# 3rd party
+import boto3
+
+# project
+from checks import AgentCheck
+
+
+class S3ObjectExists(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self._client = None
+
+    def get_client(self):
+        if self._client:
+            return self._client
+
+        credentials_path = self.init_config["credentials_json_file_path"]
+        if not os.path.isfile(credentials_path):
+            raise Exception(
+                "Credentials file does not exist: {}".format(credentials_path)
+            )
+        with open(credentials_path) as infile:
+            try:
+                all_credentials = json.load(infile)
+            except:
+                # Catch and re-raise here to avoid leaking credentials in the
+                # exception message
+                raise Exception(
+                    "Error reading or parsing JSON from {}".format(credentials_path))
+
+        key_id = all_credentials[
+            self.init_config['aws_access_key_id_field_name']]
+        access_key = all_credentials[
+            self.init_config['aws_secret_access_key_field_name']]
+        self._client = boto3.client(
+            's3',
+            aws_access_key_id=key_id,
+            aws_secret_access_key=access_key,
+        )
+        return self._client
+
+    def get_datestamp(self, now):
+        return now.strftime("%Y%m%d")
+
+    def get_date(self, now):
+        return datetime.datetime(
+            now.year, now.month, now.day, tzinfo=now.tzinfo)
+
+    def check(self, instance):
+        if 'uri' not in instance:
+            raise Exception('s3_object_exists instance missing "uri" value')
+        if 'run_time' in instance:
+            now = datetime.datetime.strptime(
+                instance['run_time'], '%Y-%m-%d %H:%M:%S')
+        else:
+            now = datetime.datetime.utcnow()
+        uri_str = instance['uri'].format(date_stamp=self.get_datestamp(now))
+        uri = urlparse(uri_str)
+        if uri.scheme.lower() != 's3':
+            raise ValueError(
+                'Invalid URI scheme: {0}, expected "s3"'.format(uri.scheme)
+            )
+        if "sla_seconds" not in instance:
+            raise Exception(
+                's3_object_exists instance missing "sla_seconds" value')
+        sla_seconds = instance["sla_seconds"]
+
+        client = self.get_client()
+        objects = []
+        list_args = {"Bucket": uri.netloc, "Prefix": uri.path}
+        while True:
+            resp = client.list_objects(**list_args)
+            objects.extend(resp['Contents'])
+            if not resp['IsTruncated']:
+                break
+            list_args["Marker"] = resp['Marker']
+
+        if 'min_size_bytes' in instance:
+            min_size = instance['min_size_bytes']
+            objects = [o for o in objects if o['Size'] >= min_size]
+        if 'max_size_bytes' in instance:
+            max_size = instance['max_size_bytes']
+            objects = [o for o in objects if o['Size'] <= max_size]
+
+        safe = objects or self.is_within_sla(sla_seconds, now)
+        message = (
+            "A S3 object was found at {0}".format(uri_str) if objects
+            else (
+                "No S3 object was found at {0} but less than {1} seconds have "
+                "elapsed since the start of the day"
+                if safe else "No S3 object was found at {0}"
+            )
+        ).format(uri_str, sla_seconds)
+        self.service_check(
+            check_name="s3.object_created_within_daily_sla",
+            status=(AgentCheck.OK if safe else AgentCheck.CRITICAL),
+            tags=instance.get('tags', []),
+            message=message,
+        )
+
+    def is_within_sla(self, sla_seconds, now):
+        date = self.get_date(now)
+        delta = (now - date).total_seconds()
+        return delta <= sla_seconds

--- a/conf.d/s3_object_exists.yaml.example
+++ b/conf.d/s3_object_exists.yaml.example
@@ -1,0 +1,9 @@
+init_config:
+  credentials_json_file_path: "/my/very/secret/secrets.json"
+  aws_access_key_id_field_name: "my_key_id"
+  aws_secret_access_key_field_name: "my_secret_access_key"
+
+instances:
+  - uri: s3://my-bucket/my/path/prefix
+    sla_seconds: 360000
+    min_size_bytes: 10000

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@
 ###########################################################
 
 boto==2.36.0
+boto3==1.4.4
 ntplib==0.3.3
 # the libyaml bindings are optional
 pyyaml==3.11

--- a/tests/checks/integration/test_s3_object_exists.py
+++ b/tests/checks/integration/test_s3_object_exists.py
@@ -1,0 +1,91 @@
+import datetime
+import os
+import json
+from tempfile import mkstemp, gettempdir
+
+# 3rd party
+from botocore import stub
+
+# project
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest, load_check
+
+
+class TestFileUnit(AgentCheckTest):
+    CHECK_NAME = 's3_object_exists'
+
+    def check_with_contents(self, *contents, **instance_config):
+        fd, path = mkstemp()
+        with os.fdopen(fd, 'w') as conf_file:
+            json.dump({"id": "the_id", "key": "the_key"}, conf_file)
+        conf = {
+            "init_config": {
+                "credentials_json_file_path": path,
+                "aws_access_key_id_field_name": "id",
+                "aws_secret_access_key_field_name": "key",
+            },
+            "instances": [
+                dict(
+                    {
+                        "uri": "s3://my-bucket/my/path/prefix/{date_stamp}",
+                        "sla_seconds": 36000,
+                        "min_size_bytes": 10000,
+                        "run_time": "2016-12-01 13:05:01",
+                    },
+                    **instance_config
+                ),
+            ],
+        }
+
+        content_default = {
+            'Key': 'part-00000-m-00000.parquet',
+            'LastModified': datetime.datetime(2015, 1, 1),
+            'ETag': 'the-tag',
+            'Size': 10000000,
+            'StorageClass': 'STANDARD',
+            'Owner': {
+                'DisplayName': 'yours truly',
+                'ID': 'my id'
+            }
+        }
+        response = {
+            'IsTruncated': False,
+            'Contents': [dict(content_default, **c) for c in contents],
+        }
+        check = load_check('s3_object_exists', conf, {})
+
+        stub_s3 = stub.Stubber(check.get_client())
+        stub_s3.add_response(
+            'list_objects',
+            response,
+        )
+        with stub_s3:
+            check.check(conf["instances"][0])
+
+        service_checks = check.get_service_checks()
+        self.assertEqual(
+            1,
+            len(service_checks),
+            "Failed to perform service checks {0!r}".format(service_checks),
+        )
+        return service_checks[0]
+
+    def test_file_present(self):
+        result = self.check_with_contents({})
+        self.assertEqual(0, result['status'], result)
+        self.assertEqual(
+            's3.object_created_within_daily_sla',
+            result['check'],
+            result)
+
+    def test_file_absent(self):
+        result = self.check_with_contents()
+        self.assertEqual(2, result['status'], result)
+
+    def test_file_absent_in_sla(self):
+        result = self.check_with_contents(sla_seconds=(60 * 60 * 23))
+        self.assertEqual(0, result['status'], result)
+
+    def test_small_file(self):
+        result = self.check_with_contents({"Size": 3})
+        self.assertEqual(2, result['status'], result)


### PR DESCRIPTION
### Summary

The SQInfra team is looking to determine when we've fallen behind on producing outputs for some of our pipelines, even before Hadoop jobs or airflow tasks have finished (or failed). Monitoring the existence of files within a time interval from the start of the day should allow us to determine if we're lagging behind schedule while our longest Scalding job is still running.

This PR introduces `S3ObjectExists`, which lets us specify an S3 URL prefix and an SLA in seconds, by which (since the start of the day, UTC), we should have generated a file.

### Motivation
Stripe JIRA: SQINFRA-25

### Testing
Nothing live, but I did manage to add some integration tests.

r? @stripe/observability 