### PR TITLE
Add splunk forwarder metrics.

### DIFF
--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -66,6 +66,9 @@ class Splunk(AgentCheck):
             self.do_search_metrics(instance_tags, url, sessionkey, timeout)
             self.do_shmember_metrics(instance_tags, url, sessionkey, timeout)
 
+        if self.is_forwarder(instance_tags, url, sessionkey, timeout):
+            self.do_forwarder_metrics(instance_tags, url, sessionkey, timeout)
+
     def is_master(self, instance_tags, url, sessionkey, timeout):
         try:
             self.get_json(url, '/services/cluster/master/info', instance_tags, sessionkey, timeout)
@@ -81,6 +84,33 @@ class Splunk(AgentCheck):
             return False
         else:
             return True
+
+    def is_forwarder(self, instance_tags, url, sessionkey, timeout):
+        try:
+            self.get_json(url, '/services/data/inputs/all', instance_tags, sessionkey, timeout)
+        except Exception as inst:
+            return False
+        else:
+            return True
+
+    def do_forwarder_metrics(self, instance_tags, url, sessionkey, timeout):
+        response = self.get_json(url, '/services/admin/inputstatus/TailingProcessor:FileStatus', instance_tags, sessionkey, timeout)
+
+        count = 0
+        for fname in response['entry'][0]['content']['inputs']:
+            input_status = response['entry'][0]['content']['inputs'][fname]
+            # Not every input is actually followed. Those that are have a few
+            # keys. We'll use percent as our signal.
+            if 'percent' in input_status:
+                count += 1
+                status_percent = input_status['percent']
+                self.gauge('splunk.forwarder.read_percentage', input_status['percent'], tags=instance_tags + [
+                    'filename:{0}'.format(fname)
+                ])
+                if status_percent != 100:
+                    self.count('splunk.forwarder.incomplete_files_total', 1, tags=instance_tags)
+
+        self.gauge('splunk.forwarder.files_read_count', count, tags=instance_tags)
 
     def do_shmember_metrics(self, instance_tags, url, sessionkey, timeout):
         response = self.get_json(url, '/services/shcluster/captain/members', instance_tags, sessionkey, timeout, params={'count': -1})


### PR DESCRIPTION
# Summary

Adds metrics for the Splunk forwarder's `TailingProcessor`.

# Motivation

We want to know if the forwarder is having trouble keeping up. This is suspected to help us detect issues with forwarders not being able to pass log lines to the indexers.

#  Notes
This does not emit any metrics unless the file is "not caught up". There is no size limit because some files are small?

`splunk.forwarder.incomplete_files_total` is tagged with `filename`. This will need to be used `as_count` and looked at as a total.

r? @stripe/observability 