### PR TITLE
Add kazoo dependency for running under docker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,8 @@ simplejson==3.6.5
 supervisor==3.1.3
 tornado==3.2.2
 uptime==3.0.1
+# required for docker service discovery backend
+kazoo==2.2.1
 
 ###########################################################
 # These modules are for checks. But they are


### PR DESCRIPTION
dd-agent (now?) requires kazoo by way of the config backends for service discovery under docker. Tests were failing, this makes them pass.

R? @cory-stripe 