### PR TITLE
add reboot_required metric, PEP8ify

### DIFF
--- a/checks.d/os_updates.py
+++ b/checks.d/os_updates.py
@@ -2,7 +2,9 @@
 from checks import AgentCheck
 from utils.platform import Platform
 
+import os
 import subprocess
+
 
 class UpdatesCheck(AgentCheck):
 
@@ -20,15 +22,18 @@ class UpdatesCheck(AgentCheck):
             return
 
         num_updates, num_security = parts
+        reboot_required = self.get_reboot_required_flag_status()
         try:
             num_updates = int(num_updates)
             num_security = int(num_security)
+            reboot_required = int(reboot_required)
         except ValueError as e:
             self.log.debug("Could not convert to integer: {0}".format(e))
             return
 
         self.gauge('updates.available', num_updates)
         self.gauge('updates.security', num_security)
+        self.gauge('updates.reboot_required', reboot_required)
 
     def get_subprocess_output(self):
         """
@@ -45,3 +50,6 @@ class UpdatesCheck(AgentCheck):
         except subprocess.CalledProcessError as e:
             self.log.debug("Could not run apt-check: {0}".format(e.returncode))
             return None
+
+    def get_reboot_required_flag_status(self):
+        return os.path.isfile('/var/run/reboot-required')

--- a/tests/checks/integration/test_os_updates.py
+++ b/tests/checks/integration/test_os_updates.py
@@ -2,8 +2,7 @@
 import mock
 
 # project
-from checks import AgentCheck
-from tests.checks.common import AgentCheckTest, load_check
+from tests.checks.common import AgentCheckTest
 
 
 class TestFileUnit(AgentCheckTest):
@@ -12,36 +11,44 @@ class TestFileUnit(AgentCheckTest):
     def __init__(self, *args, **kwargs):
         AgentCheckTest.__init__(self, *args, **kwargs)
         self.config = {
-	    "init_config": {},
-	    "instances": [{}]
+            "init_config": {},
+            "instances": [{}]
         }
 
     @mock.patch('os_updates.UpdatesCheck.get_subprocess_output', return_value='2;1')
+    @mock.patch('os_updates.UpdatesCheck.get_reboot_required_flag_status', return_value=True)
     def test_basic_check(self, *args):
         self.run_check(self.config)
 
         self.assertMetric('updates.available', value=2)
         self.assertMetric('updates.security', value=1)
+        self.assertMetric('updates.reboot_required', value=1)
 
     @mock.patch('os_updates.UpdatesCheck.get_subprocess_output', return_value=None)
+    @mock.patch('os_updates.UpdatesCheck.get_reboot_required_flag_status', return_value=None)
     def test_no_error_if_no_binary(self, *args):
         self.run_check(self.config)
 
         # Shouldn't have any metrics if we can't fetch anything
         self.assertMetric('updates.available', count=0)
         self.assertMetric('updates.security', count=0)
+        self.assertMetric('updates.reboot_required', count=0)
 
     @mock.patch('os_updates.UpdatesCheck.get_subprocess_output', return_value='not-splittable')
+    @mock.patch('os_updates.UpdatesCheck.get_reboot_required_flag_status', return_value=None)
     def test_no_error_if_bad_format(self, *args):
         self.run_check(self.config)
         self.assertMetric('updates.available', count=0)
         self.assertMetric('updates.security', count=0)
+        self.assertMetric('updates.reboot_required', count=0)
 
     @mock.patch('os_updates.UpdatesCheck.get_subprocess_output', return_value='a;b')
+    @mock.patch('os_updates.UpdatesCheck.get_reboot_required_flag_status', return_value='a')
     def test_no_error_if_not_numeric(self, *args):
         self.run_check(self.config)
         self.assertMetric('updates.available', count=0)
         self.assertMetric('updates.security', count=0)
+        self.assertMetric('updates.reboot_required', count=0)
 
     @mock.patch('utils.platform.Platform.is_linux', return_value=False)
     def test_only_on_linux(self, *args):


### PR DESCRIPTION
Add an `updates.reboot_required` metric, which'll let us indicate when boxes are in need of a reboot (because, say, they have a critical kernel update).

Also, fix a few PEP8-related things that my editor was angry about while I'm here.