### PR TITLE
Adding a splunk.stats_fetch_timeouts metric to track when we time out

### DIFF
--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -313,7 +313,8 @@ class Splunk(AgentCheck):
             elapsed_time = time.time() - start_time
             self.histogram('splunk.stats_fetch_duration_seconds', int(elapsed_time), tags = [ 'path:{0}'.format(path) ])
         except requests.exceptions.Timeout:
-            # If there's a timeout
+            # If there's a timeout, increment a count (tagged with the path in question) and then raise.
+            self.increment('splunk.stats_fetch_timeouts', tags = [ 'path:{0}'.format(path) ])
             raise Exception("Timeout when hitting URL")
 
         except requests.exceptions.HTTPError:


### PR DESCRIPTION
When we fail to fetch a particular path, right now it goes largely unremarked. This increments a counter instead.

r? @kiran-stripe 