### PR TITLE
Allow disabling forwarder metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ instances:
   - url: https://localhost:8089
     username: obsrobot
     password: foobar
+    forwarder_metrics_enabled: false # If you wanna disable this feature, it might be expensive
 ```
 
 ## SubDir Sizes

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -67,7 +67,7 @@ class Splunk(AgentCheck):
             self.do_search_metrics(instance_tags, url, sessionkey, timeout)
             self.do_shmember_metrics(instance_tags, url, sessionkey, timeout)
 
-        if forwarder_metrics_enabled
+        if forwarder_metrics_enabled:
             if self.is_forwarder(instance_tags, url, sessionkey, timeout):
                 self.do_forwarder_metrics(instance_tags, url, sessionkey, timeout)
 

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -30,7 +30,7 @@ class Splunk(AgentCheck):
         url = instance['url']
         instance_tags = instance.get('tags', []) + ['instance:{0}'.format(url)]
         default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
-        forwarder_metrics_enabled = instance.get('forwarder_metrics_enabled', True)
+        forwarder_metrics_enabled = instance.get('forwarder_metrics_enabled', False)
         username = instance.get('username')
         password = instance.get('password')
         timeout = float(instance.get('timeout', default_timeout))
@@ -67,9 +67,8 @@ class Splunk(AgentCheck):
             self.do_search_metrics(instance_tags, url, sessionkey, timeout)
             self.do_shmember_metrics(instance_tags, url, sessionkey, timeout)
 
-        if forwarder_metrics_enabled:
-            if self.is_forwarder(instance_tags, url, sessionkey, timeout):
-                self.do_forwarder_metrics(instance_tags, url, sessionkey, timeout)
+        if forwarder_metrics_enabled && self.is_forwarder(instance_tags, url, sessionkey, timeout):
+            self.do_forwarder_metrics(instance_tags, url, sessionkey, timeout)
 
     def is_master(self, instance_tags, url, sessionkey, timeout):
         try:

--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -30,6 +30,7 @@ class Splunk(AgentCheck):
         url = instance['url']
         instance_tags = instance.get('tags', []) + ['instance:{0}'.format(url)]
         default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
+        forwarder_metrics_enabled = instance.get('forwarder_metrics_enabled', True)
         username = instance.get('username')
         password = instance.get('password')
         timeout = float(instance.get('timeout', default_timeout))
@@ -66,8 +67,9 @@ class Splunk(AgentCheck):
             self.do_search_metrics(instance_tags, url, sessionkey, timeout)
             self.do_shmember_metrics(instance_tags, url, sessionkey, timeout)
 
-        if self.is_forwarder(instance_tags, url, sessionkey, timeout):
-            self.do_forwarder_metrics(instance_tags, url, sessionkey, timeout)
+        if forwarder_metrics_enabled
+            if self.is_forwarder(instance_tags, url, sessionkey, timeout):
+                self.do_forwarder_metrics(instance_tags, url, sessionkey, timeout)
 
     def is_master(self, instance_tags, url, sessionkey, timeout):
         try:


### PR DESCRIPTION
# Summary
Allow disabling forwarder metircs.

# Motivation
This is expensive as h*ck for some hosts. Let's turn it off.

# Need
Rubber stamp

# Testing
This has been verified in QA. We'll need a separate puppet change in our infra to enable and bump the version.

r? @asf-stripe 

