### PR TITLE
Change unbound histogram metric to be tagged

### DIFF
--- a/checks.d/unbound.py
+++ b/checks.d/unbound.py
@@ -45,6 +45,13 @@ class UnboundCheck(AgentCheck):
         if prefix.startswith('thread'):
             tags.append("thread:{}".format(prefix[-1]))
             metric = suffix
+        elif label.startswith('histogram'):
+            # E.g. histogram.000000.524288.to.000001.000000=59
+            # This the count of requests needing recursive processing whose processing time fell in the window
+            # specified by  <sec>.<usec>.to.<sec>.<usec>.
+            metric = "histogram"
+            _, window = label.split(".", 1)
+            tags.append("window:{}".format(window))
         elif any(label.startswith(lbl) for lbl in by_tag_labels):
             # E.g.
             # num.query.flags.QR
@@ -56,8 +63,8 @@ class UnboundCheck(AgentCheck):
         else:
             metric = label
 
-
         rate_metrics = [
+            "histogram",
             "num.queries",
             "num.cachehits",
             "num.cachemiss",

--- a/checks.d/unbound.py
+++ b/checks.d/unbound.py
@@ -51,7 +51,7 @@ class UnboundCheck(AgentCheck):
             # specified by  <sec>.<usec>.to.<sec>.<usec>.
             metric = "histogram"
             _, window = label.split(".", 1)
-            tags.append("window:{}".format(window))
+            tags.append("bucket:{}".format(window))
         elif any(label.startswith(lbl) for lbl in by_tag_labels):
             # E.g.
             # num.query.flags.QR

--- a/tests/checks/integration/test_unbound.py
+++ b/tests/checks/integration/test_unbound.py
@@ -40,6 +40,9 @@ class TestFileUnit(AgentCheckTest):
         self.assertMetric("unbound.num.query.flags", value=0, tags=['flags:RD'])
         self.assertMetric("unbound.num.query.edns", value=0, tags=['edns:present'])
         self.assertMetric("unbound.num.answer.rcode", value=0, tags=['rcode:NOERROR'])
+
+        self.assertMetric("unbound.histogram", value=0, tags=['window:000000.000000.to.000000.000001'])
+        self.assertMetric("unbound.histogram", value=0, tags=['window:008192.000000.to.016384.000000'])
         self.assertServiceCheck('unbound', AgentCheck.OK)
 
     def test_output_failure(self):

--- a/tests/checks/integration/test_unbound.py
+++ b/tests/checks/integration/test_unbound.py
@@ -41,8 +41,8 @@ class TestFileUnit(AgentCheckTest):
         self.assertMetric("unbound.num.query.edns", value=0, tags=['edns:present'])
         self.assertMetric("unbound.num.answer.rcode", value=0, tags=['rcode:NOERROR'])
 
-        self.assertMetric("unbound.histogram", value=0, tags=['window:000000.000000.to.000000.000001'])
-        self.assertMetric("unbound.histogram", value=0, tags=['window:008192.000000.to.016384.000000'])
+        self.assertMetric("unbound.histogram", value=0, tags=['bucket:000000.000000.to.000000.000001'])
+        self.assertMetric("unbound.histogram", value=0, tags=['bucket:008192.000000.to.016384.000000'])
         self.assertServiceCheck('unbound', AgentCheck.OK)
 
     def test_output_failure(self):


### PR DESCRIPTION
Currently the unbound histogram has 1 metric per bucket.  With 40 buckets, this makes any graphs around it ugly to manage.  This changes to a single `unbound.histogram` metric with tags per bucket.

The docs about this histogram can be found here (toward the bottom):
http://unbound.net/documentation/unbound-control.html 

r? @cory-stripe 