### PR TITLE
Add unix time check.

### DIFF
--- a/checks.d/unix_time.py
+++ b/checks.d/unix_time.py
@@ -1,0 +1,14 @@
+# project
+from checks import AgentCheck
+from utils.platform import Platform
+
+import time
+
+class UnixTimeCheck(AgentCheck):
+
+    def check(self, instance):
+        if not Platform.is_linux():
+            return
+
+        t = time.time()
+        self.gauge('system.current_time', t)

--- a/conf.d/unix_time.yaml.example
+++ b/conf.d/unix_time.yaml.example
@@ -1,0 +1,6 @@
+---
+init_config:
+
+# Nothing is configurable here, but the dd agent code requires something
+instances:
+  - pass: pass


### PR DESCRIPTION
# Summary

Adds check that emits a host's current time.

# Motivation

It was requested that some monitoring metrics would benefit from having a current time to compare against. As such, we need to emit the time as a gauge!

r? @stripe/observability 