### PR TITLE
Handle empty versions for a DB

### DIFF
--- a/checks.d/sequins.py
+++ b/checks.d/sequins.py
@@ -22,13 +22,14 @@ class Sequins(AgentCheck):
         for db_name, db in resp['dbs'].iteritems():
             db_tags = instance_tags + ['sequins_db:%s' % db_name]
 
-            num_dbs = len(db['versions'])
+            versions = db.get('versions', {})
+            num_dbs = len(versions)
             if num_dbs > max_dbs:
                 raise Exception("%d dbs is more than the configured maximum (%d)" % (num_dbs, max_dbs))
 
             self.gauge('sequins.version_count', num_dbs, db_tags)
 
-            for version_name, version in db['versions'].iteritems():
+            for version_name, version in versions.iteritems():
                 version_tags = db_tags + ['sequins_version:%s' % version_name]
                 self.gauge('sequins.partition_count', version['num_partitions'], version_tags)
                 self.gauge('sequins.missing_partition_count', version['missing_partitions'], version_tags)


### PR DESCRIPTION
Fixes

```
    sequins (5.14.1)
    ----------------
      - instance #0 [ERROR]: "'versions'"
        Traceback (most recent call last):
          File "/opt/datadog-agent/agent/checks/__init__.py", line 795, in run
            self.check(copy.deepcopy(instance))
          File "/etc/dd-agent/checks.d/sequins.py", line 25, in check
            num_dbs = len(db['versions'])
        KeyError: 'versions'
        
      - Collected 99 metrics, 0 events & 1 service check
```