### PR TITLE
Don't fail on missing keys from DD's AgentCheck.check

### DIFF
--- a/tests/checks/integration/test_oom.py
+++ b/tests/checks/integration/test_oom.py
@@ -45,16 +45,32 @@ class TestFileUnit(AgentCheckTest):
         for idx, obj in enumerate(service_checks):
             match = matches[idx]
 
-            self.assertEqual(obj['check'], self.CHECK_NAME, "(%s) Service check name should be %s" % (idx, self.CHECK_NAME))
+            self.assertEqual(
+                obj.get('check'),
+                self.CHECK_NAME,
+                "(%s) Service check name should be %s" % (idx, self.CHECK_NAME)
+            )
 
             if 'status' in match:
-                self.assertEqual(obj['status'], match['status'], "(%s) Status should be %s" % (idx, match['status']))
+                self.assertEqual(
+                    obj.get('status'),
+                    match.get('status'),
+                    "(%s) Status should be %s" % (idx, match.get('status'))
+                )
 
             if 'message' in match:
-                if match['message'] == None:
-                    self.assertEqual(obj['message'], None, "(%s) Service check should have no message" % idx)
+                if match.get('message') is None:
+                    self.assertEqual(
+                        obj.get('message'),
+                        None,
+                        "(%s) Service check should have no message" % idx
+                    )
                 else:
-                    self.assertRegexpMatches(obj['message'], match['message'], "(%s) Message should match %s" % (idx, match['message']))
+                    self.assertRegexpMatches(
+                        obj.get('message'),
+                        match.get('message'),
+                        "(%s) Message should match %s" % (idx, match.get('message'))
+                    )
 
     def test_no_file(self):
         self.check_and_assert('kern.nonexistent.log', [


### PR DESCRIPTION
Our CI tests run against the latest version of `dd-agent`, which apparently changed behavior. The results returned from calling `.check` now leave off the `message` key if there is no message, as opposed to specifying it with a value of `None`.

This updates the tests to be more resilient to this case (and generally changes them all to use the same approach)

R? @joshu-stripe 