### PR TITLE
Add minimum age for presence

### DIFF
--- a/conf.d/file.yaml.example
+++ b/conf.d/file.yaml.example
@@ -1,11 +1,13 @@
 # init_config:
-# # Not required for this check
 #
 # instances:
 #  - path: '/var/run/reboot-required'
 #    expected: absent
 #  - path: '/etc/passwd'
 #    expected: present
+#    Optionally require that the file be at least this many seconds old
+#    before we call it "present".
+#    present_minimum_age_seconds: 300
 
 init_config:
   # Not required for this check

--- a/conf.d/file.yaml.example
+++ b/conf.d/file.yaml.example
@@ -5,11 +5,13 @@
 #    expected: absent
 #  - path: '/etc/passwd'
 #    expected: present
-#    Optionally require that the file be at least this many seconds old
-#    before we call it "present".
+#    Optionally require that the file must be AT LEAST this many seconds old
+#    before we call it "present". This is useful for giving the file time to
+#    quiesce if tracking follower/leader behavior, bootstrapping or other
+#    transient behavior.
 #    present_minimum_age_seconds: 300
 
 init_config:
   # Not required for this check
 
-instances:
+instances: []

--- a/tests/checks/integration/test_file.py
+++ b/tests/checks/integration/test_file.py
@@ -90,9 +90,6 @@ class TestFileUnit(AgentCheckTest):
 
     def test_present_over_minimum_age_success(self):
         _, path = mkstemp()
-        # Change the temp file to be older than the minimum age we'll set below
-        oldstamp = time.time() - 100
-        os.utime(path, (oldstamp, oldstamp))
 
         conf = {
             'init_config': {},
@@ -101,7 +98,11 @@ class TestFileUnit(AgentCheckTest):
             ]
         }
         self.check = load_check('file', conf, {})
-        self.check.check(conf['instances'][0])
+
+        # Change the temp file to be older than the minimum age we'll set below
+        oldstamp = time.time() - 100
+
+        self.check.check(conf['instances'][0], file_age=oldstamp)
         metrics = self.check.get_metrics()
         self.assertTrue(len(metrics) == 1)
         metric = metrics[0]

--- a/tests/checks/integration/test_file.py
+++ b/tests/checks/integration/test_file.py
@@ -1,4 +1,6 @@
 from tempfile import mkstemp, gettempdir
+import time
+import os
 
 # project
 from checks import AgentCheck
@@ -84,4 +86,52 @@ class TestFileUnit(AgentCheckTest):
 
         service_checks = self.check.get_service_checks()
         self.assertTrue(service_checks[0]['status'] == AgentCheck.CRITICAL)
+        self.assert_tags(['expected_status:absent'], service_checks[0]['tags'])
+
+    def test_present_over_minimum_age_success(self):
+        _, path = mkstemp()
+        # Change the temp file to be older than the minimum age we'll set below
+        oldstamp = time.time() - 100
+        os.utime(path, (oldstamp, oldstamp))
+
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': path, 'expect': 'absent', 'present_minimum_age_seconds': 59}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) == 1)
+        metric = metrics[0]
+        self.assertTrue(metric[2] > 0)
+        self.assert_tags(['expected_status:absent'], metric[3]['tags'])
+        # Since the file is older then the seconds we chose, it is NOT absent
+        # and therefore critical!
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.CRITICAL)
+        self.assert_tags(['expected_status:absent'], service_checks[0]['tags'])
+
+    def test_present_under_minimum_age_success(self):
+        # This tempfile's mtime will be too new to fire!
+        _, path = mkstemp()
+
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': path, 'expect': 'absent', 'present_minimum_age_seconds': 59}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) == 1)
+        metric = metrics[0]
+        self.assertTrue(metric[2] > 0)
+        self.assert_tags(['expected_status:absent'], metric[3]['tags'])
+        # Since the file is older then the seconds we chose, it is NOT absent
+        # and therefore critical!
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.OK)
         self.assert_tags(['expected_status:absent'], service_checks[0]['tags'])


### PR DESCRIPTION
# Summary

Adds an option `present_minimum_age_seconds` that defines a file must be *at least* that many seconds old to be considered "present".

# Motivation

It's common that we want a bit of buffer between when a file appears and when we want signal flares going off. We can add this pretty easily to the `present` side of the equation.

The idea is that a file should exist for a while before we go off. This is like adding an "at all times" to service check alert, but on the emission side.

# Needs

* Does this seem like a horrible idea?
* I had to use `mtime` because you can't change the `ctime` of a file. This feels icky. Otherwise I'd have to add a `sleep` to the test and use the ctime? Should I do that?

r? @asf-stripe  