### PR TITLE
Add Veneur check to track deployed version and build age

### DIFF
--- a/checks.d/veneur.py
+++ b/checks.d/veneur.py
@@ -1,0 +1,43 @@
+import datetime
+from urlparse import urljoin
+import requests
+
+# project
+from checks import AgentCheck
+
+class Veneur(AgentCheck):
+
+    VERSION_METRIC_NAME = 'veneur.deployed_version'
+    BUILDAGE_METRIC_NAME = 'veneur.build_age'
+
+    MAX_AGE_CHECK_NAME = 'veneur.build_age.fresh'
+
+    # Check that the build is no more than one week old
+    MAX_DEPLOYMENT_INTERVAL = 604800
+
+
+    def check(self, instance):
+        success = 0
+
+        host = instance['host']
+
+        try:
+            r = requests.get(urljoin(host, '/version'))
+            sha = r.text
+            success = 1
+
+            r = requests.get(urljoin(host, '/builddate'))
+            builddate = datetime.datetime.fromtimestamp(int(r.text))
+
+            tdelta = datetime.datetime.now() - builddate
+
+            if tdelta.seconds > self.MAX_DEPLOYMENT_INTERVAL:
+                self.service_check(self.MAX_AGE_CHECK_NAME, AgentCheck.CRITICAL,
+                        message='Build date {0} is too old (build must be no more than {1} seconds old)'.format(builddate.strftime('%Y-%m-%d %H:%M:%S'), self.MAX_DEPLOYMENT_INTERVAL))
+
+        except:
+            success = 0
+            raise
+        finally:
+            self.gauge(self.VERSION_METRIC_NAME, success, tags = ['sha:{0}'.format(sha)])
+            self.histogram(self.BUILDAGE_METRIC_NAME, tdelta.seconds)

--- a/checks.d/veneur.py
+++ b/checks.d/veneur.py
@@ -9,6 +9,7 @@ class Veneur(AgentCheck):
 
     VERSION_METRIC_NAME = 'veneur.deployed_version'
     BUILDAGE_METRIC_NAME = 'veneur.build_age'
+    ERROR_METRIC_NAME = 'veneur.agent_check.errors_total'
 
     def check(self, instance):
         success = 0
@@ -24,10 +25,11 @@ class Veneur(AgentCheck):
             builddate = datetime.datetime.fromtimestamp(int(r.text))
 
             tdelta = datetime.datetime.now() - builddate
+            self.histogram(self.BUILDAGE_METRIC_NAME, tdelta.seconds)
 
         except:
             success = 0
+            self.increment(self.ERROR_METRIC_NAME)
             raise
         finally:
             self.gauge(self.VERSION_METRIC_NAME, success, tags = ['sha:{0}'.format(sha)])
-            self.histogram(self.BUILDAGE_METRIC_NAME, tdelta.seconds)

--- a/checks.d/veneur.py
+++ b/checks.d/veneur.py
@@ -10,12 +10,6 @@ class Veneur(AgentCheck):
     VERSION_METRIC_NAME = 'veneur.deployed_version'
     BUILDAGE_METRIC_NAME = 'veneur.build_age'
 
-    MAX_AGE_CHECK_NAME = 'veneur.build_age.fresh'
-
-    # Check that the build is no more than one week old
-    MAX_DEPLOYMENT_INTERVAL = 604800
-
-
     def check(self, instance):
         success = 0
 
@@ -30,10 +24,6 @@ class Veneur(AgentCheck):
             builddate = datetime.datetime.fromtimestamp(int(r.text))
 
             tdelta = datetime.datetime.now() - builddate
-
-            if tdelta.seconds > self.MAX_DEPLOYMENT_INTERVAL:
-                self.service_check(self.MAX_AGE_CHECK_NAME, AgentCheck.CRITICAL,
-                        message='Build date {0} is too old (build must be no more than {1} seconds old)'.format(builddate.strftime('%Y-%m-%d %H:%M:%S'), self.MAX_DEPLOYMENT_INTERVAL))
 
         except:
             success = 0

--- a/conf.d/veneur.yaml
+++ b/conf.d/veneur.yaml
@@ -1,0 +1,5 @@
+init_config:
+  # Not required for this check
+
+instances:
+  - host: 'http://localhost:8200'


### PR DESCRIPTION
Add Veneur check to track deployed version and build age.



r? @cory-stripe 
cc @stripe/observability 