### PR TITLE
Update port in example config for veneur check

### DIFF
--- a/conf.d/veneur.yaml
+++ b/conf.d/veneur.yaml
@@ -2,4 +2,4 @@ init_config:
   # Not required for this check
 
 instances:
-  - host: 'http://localhost:8200'
+  - host: 'http://localhost:8126'


### PR DESCRIPTION
We should use the same port we're recommending in example.yaml


r? @stripe/observability 