### PR TITLE
NSQ Check: Add support for generating tags from topic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Fetches the following metrics by polling NSQ's `/stats` endpoint:
   * `finish_count`
   * `requeue_count`
 
+If you have extra tags you would like to parse from any of your topic names, you can include `topic_name_regex` as a
+Python regex in your `init_config`. The regex will be applied to each topic name and if there is a match, the name of
+the symbolic group and the value it captured will be included as a tag key/value pair.
+
 ## Nagios Runner
 
 The Nagios Runner check takes a list of check "instances". The instances are each executed and, [according to the Nagios Plugin API](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html) the return value is inspected and a [service check](http://docs.datadoghq.com/api/#service_checks) is submitted using the provided name.

--- a/checks.d/nsq.py
+++ b/checks.d/nsq.py
@@ -84,7 +84,7 @@ class NSQ(AgentCheck):
                 topic_tags = ['topic_name:' + topic['topic_name']] + instance_tags
 
                 if topic_name_pattern:
-                    topic_tags += self._tags_from_topic_name(topic_name_pattern, topic['topic_name'])
+                    topic_tags += self.tags_from_topic_name(topic_name_pattern, topic['topic_name'])
 
                 for attr in self.TOPIC_GAUGES:
                     self.gauge('nsq.topic.' + attr, topic[attr], tags=topic_tags)
@@ -156,18 +156,18 @@ class NSQ(AgentCheck):
         return r.json()
 
 
-  def self._tags_from_topic_name(pattern, topic_name):
-      if not pattern.groupindex:
-          raise Exception('topic_names_regex was defined in init_config, but does not include any symbolic groups.')
-
-      matches = pattern.match(topic_name)
-
-      if not matches:
-          return []
-
-      tags = []
-      for tag_key in pattern.groupindex:
-          tag_value = matches.group(tag_key)
-          tags.append('{}:{}'.format(tag_key, tag_value))
-
-      return tags
+    def tags_from_topic_name(self, pattern, topic_name):
+        if not pattern.groupindex:
+            raise Exception('topic_names_regex was defined in init_config, but does not include any symbolic groups.')
+  
+        matches = pattern.match(topic_name)
+  
+        if not matches:
+            return []
+  
+        tags = []
+        for tag_key in pattern.groupindex:
+            tag_value = matches.group(tag_key)
+            tags.append('{}:{}'.format(tag_key, tag_value))
+  
+        return tags

--- a/checks.d/nsq.py
+++ b/checks.d/nsq.py
@@ -1,4 +1,5 @@
 # stdlib
+import re
 import time
 from urlparse import urljoin
 
@@ -71,11 +72,20 @@ class NSQ(AgentCheck):
             self.gauge('nsq.topic_count', len(response['data']['topics']), tags=instance_tags)
 
 
+            topic_name_pattern = None
+            topic_name_regex = self.init_config.get('topic_name_regex')
+            if topic_name_regex:
+                topic_name_pattern = re.compile(topic_name_regex)
+
             # Descend in to topic
             for topic in response['data']['topics']:
                 self.gauge('nsq.topic.channel_count', len(topic['channels']), instance_tags)
 
                 topic_tags = ['topic_name:' + topic['topic_name']] + instance_tags
+
+                if topic_name_pattern:
+                    topic_tags += self._tags_from_topic_name(topic_name_pattern, topic['topic_name'])
+
                 for attr in self.TOPIC_GAUGES:
                     self.gauge('nsq.topic.' + attr, topic[attr], tags=topic_tags)
                 for attr in self.TOPIC_COUNTS:
@@ -144,3 +154,20 @@ class NSQ(AgentCheck):
             )
 
         return r.json()
+
+
+  def self._tags_from_topic_name(pattern, topic_name):
+      if not pattern.groupindex:
+          raise Exception('topic_names_regex was defined in init_config, but does not include any symbolic groups.')
+
+      matches = pattern.match(topic_name)
+
+      if not matches:
+          return []
+
+      tags = []
+      for tag_key in pattern.groupindex:
+          tag_value = matches.group(tag_key)
+          tags.append('{}:{}'.format(tag_key, tag_value))
+
+      return tags

--- a/conf.d/nsq.yaml.example
+++ b/conf.d/nsq.yaml.example
@@ -1,5 +1,9 @@
-# This check takes no init_config
+# (Optional) `topic_name_regex` - If included, applies the given Python regular expression to each topic_name. For each
+# symbolic group captured, the name of the group will be included as a tag key, and the captured value will be the tag
+# value. In this example, the "service-prod" topic will include the tag stage:prod and the "service-canary" topic will
+# include the tag stage:canary. The regex must include at least one symbolic group.
 init_config:
+    - topic_name_regex: "service-(?P<stage>prod|canary)$"
 
 instances:
     # Where your NSQD HTTP Server Lives

--- a/conf.d/nsq.yaml.example
+++ b/conf.d/nsq.yaml.example
@@ -3,7 +3,7 @@
 # value. In this example, the "service-prod" topic will include the tag stage:prod and the "service-canary" topic will
 # include the tag stage:canary. The regex must include at least one symbolic group.
 init_config:
-    - topic_name_regex: "service-(?P<stage>prod|canary)$"
+    topic_name_regex: "service-(?P<stage>prod|canary)$"
 
 instances:
     # Where your NSQD HTTP Server Lives

--- a/tests/checks/integration/test_nsq.py
+++ b/tests/checks/integration/test_nsq.py
@@ -1,0 +1,24 @@
+import re
+from tests.checks.common import AgentCheckTest, load_check
+
+
+class TestFileUnit(AgentCheckTest):
+    CHECK_NAME = 'nsq'
+
+
+    def test_tags_from_topic_name(self):
+        conf = {
+            'init_config': {'topic_name_regex': 'service-(?P<stage>prod|canary)$'},
+            'instances': [{'url': 'http://localhost:4151'}]
+        }
+        pattern = re.compile(conf['init_config']['topic_name_regex'])
+        check = load_check('nsq', conf, {})
+        
+        prod_result = check.tags_from_topic_name(pattern, 'service-prod')
+        self.assertEqual(prod_result, ['stage:prod'])
+
+        canary_result = check.tags_from_topic_name(pattern, 'service-canary')
+        self.assertEqual(canary_result, ['stage:canary'])
+
+        empty_result = check.tags_from_topic_name(pattern, 'other-topic')
+        self.assertEqual(empty_result, [])


### PR DESCRIPTION
#### Summary
For the NSQ check, adds a configuration option for specifying a regex that will be applied to each topic name. For matched symbolic groups, a tag key/value pair will be added based on the name of the group and the value it matched.

#### Motivation
One example of a situation where this would be useful is if a user has multiple NSQ topics related to the same service. They can parse tags out of the topic name in order to aggregate metrics from different topics.

#### Testing
I wrote a unit test for this function. I also ran the Datadog check on a sample NSQ instance and confirmed that the tags would be parsed.

#### Rollback?
No problem!