### PR TITLE
Add boolean versions of os_updates metrics

### DIFF
--- a/checks.d/os_updates.py
+++ b/checks.d/os_updates.py
@@ -27,8 +27,14 @@ class UpdatesCheck(AgentCheck):
             self.log.debug("Could not convert to integer: {0}".format(e))
             return
 
+        # We create "boolean" versions of these metrics because Datadog doesn't
+        # seem to have a way to compute them in queries.
+
         self.gauge('updates.available', num_updates)
+        self.gauge('updates.available.boolean', 1 if num_updates > 0 else 0)
+
         self.gauge('updates.security', num_security)
+        self.gauge('updates.security.boolean', 1 if num_security > 0 else 0)
 
     def get_subprocess_output(self):
         """


### PR DESCRIPTION
It seems to be impossible to create queries in Datadog that count the number of hosts missing updates or security updates based on the `updates.available` and `updates.security` metrics. To work around this limitation, this commit adds `.boolean` versions of the existing `updates.available` and `updates.security` metrics that get set to 0 or 1 depending on whether or not the corresponding non-`.boolean` metric is greater than 0.