### PR TITLE
Add datadog check for kernel version

### DIFF
--- a/checks.d/kernel.py
+++ b/checks.d/kernel.py
@@ -1,0 +1,53 @@
+import subprocess
+
+from checks import AgentCheck
+
+
+class Veneur(AgentCheck):
+
+    KERNEL_METRIC_NAME = 'linux.kernel'
+    ERROR_METRIC_NAME = 'linux.kernel.agent_check.errors_total'
+
+    def get_kernel_version(self):
+        return subprocess.check_call(['uname', '-r']).strip()
+
+    def get_linux_release(self):
+        return subprocess.check_call(['lsb_release', '-sc']).strip()
+
+    def get_grub_menu_lines(self):
+        with open("/boot/grub/menu.lst") as menu_fh:
+            return menu_fh.readlines()
+
+    def get_grub_default(self):
+        try:
+            menu_lines = self.get_grub_menu_lines()
+            default_line = next(l for l in menu_lines
+                                if l.startswith("title"))
+            grub_default = default_line.split()[-1]
+        except:
+            # Ignore failures for grub default since it could
+            # be a different format
+            pass
+
+        return grub_default
+
+    def check(self, instance):
+        success = 0
+        grub_default = 'unknown'
+
+        try:
+            kernel = self.get_kernel_version()
+            release = self.get_linux_release()
+            grub_default = self.get_grub_default()
+            success = 1
+        except:
+            self.increment(self.ERROR_METRIC_NAME)
+            raise
+        finally:
+            tags = instance.get('tags', [])
+            tags.extend([
+                'kernel:{}'.format(kernel),
+                'release:{}'.format(release),
+                'grub_default:{}'.format(grub_default),
+            ])
+            self.gauge(self.KERNEL_METRIC_NAME, success, tags=tags)

--- a/checks.d/kernel.py
+++ b/checks.d/kernel.py
@@ -9,10 +9,10 @@ class Veneur(AgentCheck):
     ERROR_METRIC_NAME = 'linux.kernel.agent_check.errors_total'
 
     def get_kernel_version(self):
-        return subprocess.check_call(['uname', '-r']).strip()
+        return subprocess.check_output(['uname', '-r']).strip()
 
     def get_linux_release(self):
-        return subprocess.check_call(['lsb_release', '-sc']).strip()
+        return subprocess.check_output(['lsb_release', '-sc']).strip()
 
     def get_grub_menu_lines(self):
         with open("/boot/grub/menu.lst") as menu_fh:
@@ -34,6 +34,8 @@ class Veneur(AgentCheck):
     def check(self, instance):
         success = 0
         grub_default = 'unknown'
+        kernel = 'unknown'
+        release = 'unknown'
 
         try:
             kernel = self.get_kernel_version()

--- a/tests/checks/integration/test_kernel.py
+++ b/tests/checks/integration/test_kernel.py
@@ -1,0 +1,43 @@
+
+# project
+from tests.checks.common import AgentCheckTest, load_check
+
+
+class TestKernelUnit(AgentCheckTest):
+    CHECK_NAME = 'kernel'
+
+    def test_check_exists(self):
+        conf = {}
+        load_check(self.CHECK_NAME, conf, {})
+
+    def test_output(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {}
+            ]
+        }
+
+        def get_linux_release():
+            return 'xenial'
+
+        def get_kernel_version():
+            return '1.2.3.4-generic'
+
+        def get_grub_menu_lines():
+            return [
+                '# title stuff about grub \n',
+                'some other stufff\n',
+                'title\t\tUbuntu 16.04.5 LTS, kernel 1.2.3.3-generic\n',
+            ]
+
+        self.run_check(conf, mocks={
+            'get_linux_release': get_linux_release,
+            'get_kernel_version': get_kernel_version,
+            'get_grub_menu_lines': get_grub_menu_lines,
+        })
+
+        self.assertMetric("linux.kernel", value=1, metric_type='gauge',
+                          tags=['kernel:1.2.3.4-generic',
+                                'release:xenial',
+                                'grub_default:1.2.3.3-generic'])


### PR DESCRIPTION
Adds a check for reporting the kernel version and default grub entry.  The default grub entry will indicate which kernel will be loaded on reboot. 

r? @cory-stripe 