### PR TITLE
Fix kernel check when no grub default found

### DIFF
--- a/checks.d/kernel.py
+++ b/checks.d/kernel.py
@@ -19,6 +19,7 @@ class Veneur(AgentCheck):
             return menu_fh.readlines()
 
     def get_grub_default(self):
+        grub_default = 'unknown'
         try:
             menu_lines = self.get_grub_menu_lines()
             default_line = next(l for l in menu_lines

--- a/tests/checks/integration/test_kernel.py
+++ b/tests/checks/integration/test_kernel.py
@@ -41,3 +41,34 @@ class TestKernelUnit(AgentCheckTest):
                           tags=['kernel:1.2.3.4-generic',
                                 'release:xenial',
                                 'grub_default:1.2.3.3-generic'])
+
+    def test_output_no_grub(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {}
+            ]
+        }
+
+        def get_linux_release():
+            return 'trusty'
+
+        def get_kernel_version():
+            return '1.2.3.4-generic'
+
+        def get_grub_menu_lines():
+            return [
+                '# title stuff about grub \n',
+                'no title here\n',
+            ]
+
+        self.run_check(conf, mocks={
+            'get_linux_release': get_linux_release,
+            'get_kernel_version': get_kernel_version,
+            'get_grub_menu_lines': get_grub_menu_lines,
+        })
+
+        self.assertMetric("linux.kernel", value=1, metric_type='gauge',
+                          tags=['kernel:1.2.3.4-generic',
+                                'release:trusty',
+                                'grub_default:unknown'])


### PR DESCRIPTION
Previously the kernel version check would throw an error and due to grub_default not being known ahead of time. This sets a default.

r? @cory 