### PR TITLE
Add the sha to the tags in a way that won't cause an error

### DIFF
--- a/checks.d/veneur.py
+++ b/checks.d/veneur.py
@@ -15,10 +15,11 @@ class Veneur(AgentCheck):
         success = 0
 
         host = instance['host']
+        tags = instance.get('tags', [])
 
         try:
             r = requests.get(urljoin(host, '/version'))
-            sha = r.text
+            tags.extend(['sha:{0}'.format(r.text)])
             success = 1
 
             r = requests.get(urljoin(host, '/builddate'))
@@ -32,6 +33,4 @@ class Veneur(AgentCheck):
             self.increment(self.ERROR_METRIC_NAME)
             raise
         finally:
-            tags = instance.get('tags', [])
-            tags.extend(['sha:{0}'.format(sha)])
             self.gauge(self.VERSION_METRIC_NAME, success, tags = tags)


### PR DESCRIPTION
We were seeing a case where this errored on trying to get `sha`, which might not be set during the `finally` block. This ensures that we get the sha tag only when it's set and handle the error gracefully.

r? @aditya-stripe 