### PR TITLE
Allow configuration of metrics to emit

### DIFF
--- a/checks.d/linux_vm_extras.py
+++ b/checks.d/linux_vm_extras.py
@@ -14,6 +14,8 @@ class MoreLinuxVMCheck(AgentCheck):
     def check(self, instance):
         tags = instance.get('tags', [])
 
+        enabled_metrics = instance.get('enabled_metrics', list(VM_COUNTS.keys()))
+
         with open('/proc/vmstat', 'r') as vm_info:
             content = [line.strip().split() for line in vm_info.readlines()]
 

--- a/conf.d/linux_vm_extras.yaml.example
+++ b/conf.d/linux_vm_extras.yaml.example
@@ -1,4 +1,5 @@
 init_config:
- 2
- 3 instances:
- 4   - tags: []
+
+instances:
+  - tags: []
+    enabled_metrics: [ 'pgpgin', 'pgpgout', 'pswpin', 'pswpout', 'pgfault', 'pgmajfault' ]


### PR DESCRIPTION
We don't always want all these metrics, so allow them to be whitelisted!

r? @stripe/observability 