### PR TITLE
Swap out veneur metric for a gauge

### DIFF
--- a/checks.d/veneur.py
+++ b/checks.d/veneur.py
@@ -8,7 +8,7 @@ from checks import AgentCheck
 class Veneur(AgentCheck):
 
     VERSION_METRIC_NAME = 'veneur.deployed_version'
-    BUILDAGE_METRIC_NAME = 'veneur.build_age'
+    BUILDAGE_METRIC_NAME = 'veneur.build_age_seconds'
     ERROR_METRIC_NAME = 'veneur.agent_check.errors_total'
 
     def check(self, instance):
@@ -26,7 +26,7 @@ class Veneur(AgentCheck):
             builddate = datetime.datetime.fromtimestamp(int(r.text))
 
             tdelta = datetime.datetime.now() - builddate
-            self.histogram(self.BUILDAGE_METRIC_NAME, tdelta.total_seconds())
+            self.gauge(self.BUILDAGE_METRIC_NAME, tdelta.total_seconds())
 
         except:
             success = 0


### PR DESCRIPTION
Veneur doesn't run > 1 instance on a box. To that end, using a histogram doesn't make a ton of sense, as it creates a bunch of add-on metrics (sum, percentiles, count, min max) when it only really needs "last value".

This will break our existing monitor, but I'll fix that when I puppet it.

r? @aditya-stripe 