### PR TITLE
Splunk: Optionally emit a counter, histogram, or nothing with get_json

### DIFF
--- a/lib/stats_helpers.py
+++ b/lib/stats_helpers.py
@@ -1,0 +1,49 @@
+from timeit import default_timer as timer
+
+class Timing:
+    WITH_COUNT = 1
+    WITH_TIMING = 2
+
+    def __init__(self, check, metric_name, tags={}, emit=None):
+        self.check = check
+        self.metric_name = metric_name
+        self.extra_tags = tags
+        self.emit = emit
+    def __enter__(self):
+        self.start = timer()
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.end = timer()
+
+        # tag with error presence and type
+        tag_dict = {}
+        if exc_type:
+            tag_dict['is_error'] = 'true'
+            try:
+                tag_dict['error_type'] = exc_type.__name__.lower()
+            except AttributeError:
+                tag_dict['error_type'] = 'unknown'
+        else:
+            tag_dict['is_error'] = 'false'
+            tag_dict['error_type'] = 'none'
+
+        # tag with user-supplied tags, which are allowed to override error tags
+        tag_dict.update(self.extra_tags)
+
+        tags = ["%s:%s" % (k, v) for k, v in tag_dict.iteritems()]
+
+        # emit either a call count or a full timing histogram
+        if self.emit == self.WITH_TIMING:
+            self.check.histogram(
+                self.metric_name,
+                int((self.end - self.start) * 1000),
+                tags=tags
+            )
+        elif self.emit == self.WITH_COUNT:
+            self.check.increment(
+                # this is intended to match the format of *just* the count portion
+                # of a histogram call. since check.histogram adds these suffixes
+                # implicitly, but we're calling increment here, we need to add
+                # it explicitly
+                '%s.count' % self.metric_name,
+                tags=tags
+            )

--- a/tests/lib/test_stats_helpers.py
+++ b/tests/lib/test_stats_helpers.py
@@ -1,0 +1,143 @@
+# Add lib/ to the import path:
+import sys
+import os
+agent_lib_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../lib')
+sys.path.insert(1, agent_lib_dir)
+
+from time import sleep
+
+# project
+import unittest
+import logging
+
+from stats_helpers import Timing
+
+class MockException(Exception):
+    pass
+
+class MockCheck():
+    def __init__(self, test):
+        self.metrics = []
+        self.test = test
+    def increment(self, name, **kwargs):
+        self.metrics.append((name, 'increment', 1, kwargs))
+    def histogram(self, name, value, **kwargs):
+        self.metrics.append((name, 'histogram', value, kwargs))
+    def check_and_assert(self, expected):
+        expected_metrics = len(expected)
+        got_metrics = len(self.metrics)
+        self.test.assertEqual(
+            expected_metrics,
+            got_metrics,
+            "Expected %s metrics, got %s" % (
+                expected_metrics,
+                got_metrics
+            )
+        )
+        for idx, got in enumerate(self.metrics):
+            expected = expected[idx]
+            for idx, expectation_type in enumerate(['name', 'type', 'value']):
+                if idx < len(expected) and expected[idx]:
+                    self.test.assertEqual(
+                        expected[idx],
+                        got[idx],
+                        "(%s) Expected metric %s `%s`, got `%s`" % (
+                            expected[0],
+                            expectation_type,
+                            expected[idx],
+                            got[idx]
+                        )
+                    )
+            if len(expected) == 4:
+                if 'tags' in expected[3]:
+                    expected_tags = sorted(expected[3]['tags'])
+                    got_tags = sorted(got[3]['tags'])
+                    self.test.assertEqual(
+                        expected_tags,
+                        got_tags,
+                        "(%s) Expected tags %s, got %s" % (
+                            expected[0],
+                            expected_tags,
+                            got_tags
+                        )
+                    )
+
+class TestFileUnit(unittest.TestCase):
+    def test_default(self):
+        check = MockCheck(self)
+
+        with Timing(check, 'foo'):
+            pass
+
+        check.check_and_assert([])
+
+    def test_without_timing(self):
+        check = MockCheck(self)
+
+        with Timing(check, 'foo', emit=Timing.WITH_COUNT):
+            pass
+
+        check.check_and_assert([
+            ['foo.count', 'increment', None, {'tags': [
+                'is_error:false',
+                'error_type:none'
+            ]}]
+        ])
+
+    def test_with_timing(self):
+        check = MockCheck(self)
+
+        with Timing(check, 'foo', emit=Timing.WITH_TIMING):
+            sleep(0.1)
+
+        check.check_and_assert([
+            ['foo', 'histogram', None, {'tags': [
+                'is_error:false',
+                'error_type:none'
+            ]}]
+        ])
+
+        self.assertTrue(check.metrics[0][2] >= 0.1, "Expected a timing value >= 0.1")
+
+    def test_count_with_tags(self):
+        check = MockCheck(self)
+
+        with Timing(check, 'foo', emit=Timing.WITH_COUNT, tags={'foo':'bar'}):
+            pass
+
+        check.check_and_assert([
+            ['foo.count', 'increment', None, {'tags': [
+                'is_error:false',
+                'error_type:none',
+                'foo:bar'
+            ]}]
+        ])
+
+    def test_with_tag_override(self):
+        check = MockCheck(self)
+
+        with Timing(check, 'foo', emit=Timing.WITH_COUNT, tags={'error_type':'keke'}):
+            pass
+
+        check.check_and_assert([
+            ['foo.count', 'increment', None, {'tags': [
+                'is_error:false',
+                'error_type:keke'
+            ]}]
+        ])
+
+    def test_with_error(self):
+        check = MockCheck(self)
+
+        try:
+            with Timing(check, 'foo', emit=Timing.WITH_COUNT):
+                raise MockException("foo")
+        except MockException:
+            pass
+
+        check.check_and_assert([
+            ['foo.count', 'increment', None, {'tags': [
+                'is_error:true',
+                'error_type:mockexception',
+            ]}]
+        ])


### PR DESCRIPTION
We want to get validation that the forwarders are running through this check; removing the histograms means we don't get reliable metrics on those API calls anymore. This adds back that ability: you can specify whether to emit full histograms, just counts, or nothing.

Future work: make configurable in the check config.

Wrote automated tests for the timing wrapper, tested manually in QA with `dd-agent check`. Exactly one new metric is present.

R? @cory-stripe 