### PR TITLE
Don't bomb out of the check with an exception. Catch other kinds of errors.

### DIFF
--- a/checks.d/splunk.py
+++ b/checks.d/splunk.py
@@ -50,14 +50,19 @@ class Splunk(AgentCheck):
             self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
                 message='Timed out after {0} seconds.'.format(timeout),
                 tags = instance_tags)
-            raise Exception("Timeout when hitting URL")
+            return
 
         except requests.exceptions.HTTPError:
             self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
                 message='Returned a status of {0}'.format(r.status_code),
                 tags = instance_tags)
-            raise Exception("Got {0} when hitting URL".format(r.status_code))
+            return
 
+        except Exception as e:
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message='Got exception {0}: {1}'.format(e.__class__.__name__, e),
+                tags = instance_tags)
+            return
         else:
             self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.OK,
                 tags = instance_tags


### PR DESCRIPTION
Raising exceptions makes dd-agent not emit the can_connect false status checks, so return instead. Catch exceptions other than timeout and http status (notably: failed to connect).

File needs more cleanup, but this'll get us started.

R? @cory-stripe 
Should I revert the other PR? I thought it would be a clean approach, but it turns out to be not very useful without more work