### PR TITLE
Silver fix NSQ check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 /venv
+.idea/

--- a/checks.d/nsq.py
+++ b/checks.d/nsq.py
@@ -117,16 +117,18 @@ class NSQ(AgentCheck):
                         for attr in self.CLIENT_COUNTS:
                             self.monotonic_count('nsq.topic.channel.client.' + attr, client[attr], tags=client_tags)
 
-                    for latency in channel['e2e_processing_latency']['percentiles']:
-                        # NSQ does not zero pad the quantile's numberic representation,
-                        # so we'll do that by splitting on the . and left-justifying up to
-                        # 2 spaces, filling with 0. Note that `ljust` returns the whole strong
-                        # if it is >= the length. This converts 0.5 in to '50' and .9999 in to '9999'
-                        if latency['quantile'] == 1:
-                            quantile = '100'
-                        else:
-                            quantile = str(latency['quantile']).split(".")[1].ljust(2, "0")
-                        self.gauge('nsq.topic.channel.e2e_processing_latency.p' + quantile, latency['value'], tags=channel_tags)
+                    latency_percentiles = channel['e2e_processing_latency']['percentiles']
+                    if latency_percentiles is not None:
+                        for latency in latency_percentiles:
+                            # NSQ does not zero pad the quantile's numberic representation,
+                            # so we'll do that by splitting on the . and left-justifying up to
+                            # 2 spaces, filling with 0. Note that `ljust` returns the whole strong
+                            # if it is >= the length. This converts 0.5 in to '50' and .9999 in to '9999'
+                            if latency['quantile'] == 1:
+                                quantile = '100'
+                            else:
+                                quantile = str(latency['quantile']).split(".")[1].ljust(2, "0")
+                            self.gauge('nsq.topic.channel.e2e_processing_latency.p' + quantile, latency['value'], tags=channel_tags)
 
     def get_json(self, url, timeout):
         try:


### PR DESCRIPTION
For reasons I'm not totally sure about, sometimes `nsqd` doesn't have anything useful to say about end to end processing latency, in which case it doesn't have any percentiles to report, which this check then crashes on. This guards against that case.

Also I use PyCharm, so ignoring the `.idea` directory :P

For context: https://jira.corp.stripe.com/browse/OBS-5905

r? @sjung-stripe 