### PR TITLE
Segfault fixes/updates

### DIFF
--- a/checks.d/segfault.py
+++ b/checks.d/segfault.py
@@ -35,7 +35,9 @@ class Segfault(AgentCheck):
             kernel_line_regex = re.compile(instance['kernel_line_regex'])
 
             # the regex to extract the process name from the message with
-            process_name_regex = re.compile(instance['process_name_regex'])
+            process_name_regex = None
+            if 'process_name_regex' in instance:
+                process_name_regex = re.compile(instance['process_name_regex'])
 
             # the format to parse the timestamp from
             # %b %d %H:%M:%S
@@ -68,6 +70,11 @@ class Segfault(AgentCheck):
         with fh:
             for line in reverse_readline(fh):
                 kern_results = regex_matches(line, kernel_line_regex)
+
+                # no match = skip this line
+                if not kern_results:
+                    continue
+
                 message = kern_results.get('message', None)
                 timestamp = kern_results.get('timestamp', None)
 
@@ -84,18 +91,27 @@ class Segfault(AgentCheck):
                     # we only look back X seconds; we can end early if we hit a timestamp earlier than that
                     break
 
-                pname_results = regex_matches(message, process_name_regex)
-                if not pname_results:
-                    # process name regex matches segfault events. no match = not a segfault message
-                    continue
+                # process name regex is an extra regex to extract the process name
+                # from the 'message' capturing group. behaves the same as kernel_line_regex
+                # in that a failed match = skip this line. if unspecified, do not extract
+                # a process name
+                process_name = None
+                if process_name_regex:
+                    pname_results = regex_matches(message, process_name_regex)
+                    if not pname_results:
+                        continue
 
-                process_name = pname_results.get('process', '_unknown_')
+                    process_name = pname_results.get('process', None)
 
                 counts[process_name] += 1
 
         for pname, num_segfaults in counts.iteritems():
-            metric_tags = self.tags(
-                'process:%s' % pname,
-                'time_window:%s' % time_window_seconds,
-            )
+            tags = ['time_window:%s' % time_window_seconds]
+            # sometimes the process name isn't present / can't be extracted
+            # we might want to put the process name in the tag config, so don't
+            # add on an extra 'process' tag that's empty in addition
+            if pname:
+                tags.append('process:%s' % pname)
+
+            metric_tags = self.tags(*tags)
             self.gauge('system.segfault.count', num_segfaults, tags=metric_tags)

--- a/checks.d/segfault.py
+++ b/checks.d/segfault.py
@@ -36,7 +36,7 @@ class Segfault(AgentCheck):
 
             # the regex to extract the process name from the message with
             process_name_regex = None
-            if 'process_name_regex' in instance:
+            if 'process_name_regex' in instance and instance['process_name_regex']:
                 process_name_regex = re.compile(instance['process_name_regex'])
 
             # the format to parse the timestamp from

--- a/tests/checks/integration/fixtures/segfault/kern.garbage.log
+++ b/tests/checks/integration/fixtures/segfault/kern.garbage.log
@@ -1,0 +1,3 @@
+this deliberately shouldn't match
+any of the regexes
+in the tests

--- a/tests/checks/integration/test_segfault.py
+++ b/tests/checks/integration/test_segfault.py
@@ -129,6 +129,13 @@ class TestFileUnit(AgentCheckTest):
         metrics = self.check_and_assert('kern.clean.log', [])
         self.assertEqual(len(metrics), 0, "Expected no metrics, got: %s" % metrics)
 
+    def test_non_matching(self):
+        metrics = self.check_and_assert('kern.garbage.log', [])
+        self.assertEqual(len(metrics), 0, "Expected no metrics, got: %s" % metrics)
+        metrics = self.check_and_assert('kern.envoy_segfaults.log', [], time_window_seconds=65, process_name_regex='whaargarbl')
+        self.assertEqual(len(metrics), 0, "Expected no metrics, got: %s" % metrics)
+
+
     def test_segfaults(self):
         self.check_and_assert('kern.envoy_segfaults.log', [
             { 'name': 'system.segfault.count', 'type': 'gauge', 'value': 1.0, 'tags': ['process:envoy', 'time_window:65'] }
@@ -140,3 +147,11 @@ class TestFileUnit(AgentCheckTest):
             { 'name': 'system.segfault.count', 'type': 'gauge', 'value': 1.0, 'tags': ['process:anvoy', 'time_window:7200'] },
             { 'name': 'system.segfault.count', 'type': 'gauge', 'value': 3.0, 'tags': ['process:envoy', 'time_window:7200'] },
         ], time_window_seconds=7200)
+
+    def test_segfault_no_process(self):
+        self.check_and_assert('kern.envoy_segfaults.log', [
+            { 'name': 'system.segfault.count', 'type': 'gauge', 'value': 1.0, 'tags': ['time_window:65'] }
+        ], time_window_seconds=65, process_name_regex=None)
+        self.check_and_assert('kern.envoy_segfaults.log', [
+            { 'name': 'system.segfault.count', 'type': 'gauge', 'value': 1.0, 'tags': ['process:yovne', 'time_window:65'] }
+        ], time_window_seconds=65, process_name_regex=None, tags=['process:yovne'])


### PR DESCRIPTION
Apparently not all segfaults go to kern.log. Updated to add a little extra flexibility for processing other types of log files.

R? @cory-stripe