### PR TITLE
allows sending jenkins metric healthcheck

### DIFF
--- a/conf.d/jenkins_metrics.yaml
+++ b/conf.d/jenkins_metrics.yaml
@@ -2,3 +2,4 @@ init_config:
 
 instances:
   # - url: "http://localhost:8080/metrics/ACCESS_KEY_HERE/metrics"
+  # - url: "http://localhost:8080/metrics/ACCESS_KEY_HERE/healthcheck"


### PR DESCRIPTION
Metrics plugin has /metrics and /healthcheck endpoints. This allows
sending data from /healthcheck endpoint as DataDog service_check.