### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/checks.d/file.py
+++ b/checks.d/file.py
@@ -32,7 +32,7 @@ class FileCheck(AgentCheck):
                 return self.STATUS_PRESENT, statinfo
             else:
                 return self.STATUS_ABSENT, []
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 return self.STATUS_ABSENT, []
             else:

--- a/checks.d/oom.py
+++ b/checks.d/oom.py
@@ -19,7 +19,7 @@ class OOM(AgentCheck):
 
         try:
             fh = open(instance.get('logfile'), 'rt')
-        except IOError, err:
+        except IOError as err:
             if err.errno == errno.ENOENT:
                 level = AgentCheck.WARNING
             else:

--- a/checks.d/segfault.py
+++ b/checks.d/segfault.py
@@ -48,18 +48,18 @@ class Segfault(AgentCheck):
 
             # the logfile to read from
             logfile_path = instance['logfile']
-        except KeyError, e:
+        except KeyError as e:
             self.increment('system.segfault.errors', tags=self.tags('type:config'))
             print >> sys.stderr, "Instance config: Key `%s` is required" % e.args[0]
             return
-        except TypeError, e:
+        except TypeError as e:
             self.increment('system.segfault.errors', tags=self.tags('type:config'))
             print >> sys.stderr, "Error loading config: %s" % e
             return
 
         try:
             fh = open(logfile_path, 'rt')
-        except IOError, err:
+        except IOError as err:
             self.increment('system.segfault.errors', tags=self.tags('type:io'))
             return
 

--- a/checks.d/storm_rest_api.py
+++ b/checks.d/storm_rest_api.py
@@ -39,7 +39,7 @@ StormConfig = namedtuple(
 )
 
 class StormRESTCheck(AgentCheck):
-    class ConnectionFailure(StandardError):
+    class ConnectionFailure(Exception):
         def __init__(self, url, timeout):
             self.url = url
             self.timeout = timeout

--- a/checks.d/subdir_sizes.py
+++ b/checks.d/subdir_sizes.py
@@ -92,7 +92,7 @@ class SubDirSizesCheck(AgentCheck):
 
                 try:
                     file_stat = stat(filename)
-                except OSError, ose:
+                except OSError as ose:
                     self.warning("DirectoryCheck: could not stat file %s - %s" % (filename, ose))
                 else:
                     subdir_bytes += file_stat.st_size

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # stdlib
 import copy
 import inspect
@@ -22,6 +23,11 @@ except ImportError:
     from utils.platform import get_os
 
 from utils.debug import get_check  # noqa -  FIXME 5.5.0 AgentCheck tests should not use this
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 log = logging.getLogger('tests')
 
@@ -205,10 +211,10 @@ class AgentCheckTest(unittest.TestCase):
                 self.check.check(copy.deepcopy(instance))
                 # FIXME: This should be called within the `run` method only
                 self.check._roll_up_instance_metadata()
-            except Exception, e:
+            except Exception as e:
                 # Catch error before re-raising it to be able to get service_checks
-                print "Exception {0} during check".format(e)
-                print traceback.format_exc()
+                print("Exception {0} during check".format(e))
+                print(traceback.format_exc())
                 error = e
         self.metrics = self.check.get_metrics()
         self.events = self.check.get_events()

--- a/tests/checks/integration/test_oom.py
+++ b/tests/checks/integration/test_oom.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from os import path, getuid
 #from tempfile import mkstemp, gettempdir
 
@@ -90,7 +91,7 @@ class TestFileUnit(AgentCheckTest):
                 { 'status': AgentCheck.CRITICAL, 'message': 'Permission denied' }
             ])
         else:
-            print "Skipping"
+            print("Skipping")
 
     def test_no_kills(self):
         self.check_and_assert('kern.clean.log', [

--- a/tests/checks/integration/test_segfault.py
+++ b/tests/checks/integration/test_segfault.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from os import path, getuid
 #from tempfile import mkstemp, gettempdir
 
@@ -123,7 +124,7 @@ class TestFileUnit(AgentCheckTest):
                 { 'name': 'system.segfault.errors', 'type': 'rate', 'tags': ['type:io'] }
             ])
         else:
-            print "Skipping"
+            print("Skipping")
 
     def test_no_segfaults(self):
         metrics = self.check_and_assert('kern.clean.log', [])

--- a/tests/checks/integration/test_storm_rest_api.py
+++ b/tests/checks/integration/test_storm_rest_api.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # project
 from checks import AgentCheck
 from tests.checks.common import AgentCheckTest, load_check
@@ -60,7 +61,7 @@ class TestFileUnit(AgentCheckTest):
 
         cluster_slots_used = self.find_metric(metrics, 'storm.rest.cluster.slots_used_count')
         self.assertEqual(7, cluster_slots_used[2])
-        print cluster_slots_used
+        print(cluster_slots_used)
         self.assert_tags(['cluster_want:form'], cluster_slots_used[3]['tags'])
 
         for metric_name in ['supervisor_count', 'slots_total_count', 'slots_free_count', 'executors_total_count', 'tasks_total_count']:
@@ -157,7 +158,7 @@ class TestFileUnit(AgentCheckTest):
         metrics = self.check.get_metrics()
         spout_workers_metric = self.find_metric(metrics, 'storm.rest.spout.executors_total', ['storm_task_id:somespout'])
         self.assertEqual(48, spout_workers_metric[2])
-        print spout_workers_metric[3]
+        print(spout_workers_metric[3])
         self.assert_tags(['storm_topology:sometopo', 'storm_task_id:somespout', 'is_a_great_spout:true'], spout_workers_metric[3]['tags'])
 
         complete_latency_metric = self.find_metric(metrics, 'storm.rest.spout.complete_latency_us', ['storm_task_id:somespout'])


### PR DESCRIPTION
* Old style exceptions --> new style for Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.