### PR TITLE
Jeffjo/check multiple unbound instances

### DIFF
--- a/checks.d/unbound.py
+++ b/checks.d/unbound.py
@@ -124,7 +124,7 @@ class UnboundCheck(AgentCheck):
                 AgentCheck.CRITICAL,
                 message=error_msg,
             )
-            self.log.error()
+            self.log.error(error_msg)
             return None
 
         return output

--- a/checks.d/unbound.py
+++ b/checks.d/unbound.py
@@ -99,16 +99,21 @@ class UnboundCheck(AgentCheck):
         self.gauge_metrics= gauge_metrics + ["total.{}".format(m) for m in gauge_metrics]
         self.exclude_metrics = exclude_metrics + ["total.{}".format(m) for m in exclude_metrics]
 
-    def get_cmd(self):
-        if self.init_config.get('sudo'):
-            cmd = 'sudo unbound-control stats'
+    def get_cmd(self, config_path=None):
+        if config_path is not None:
+            config_path_arg = "-c {}".format(config_path)
         else:
-            cmd = 'unbound-control stats'
+            config_path_arg = ""
+
+        if self.init_config.get('sudo'):
+            cmd = 'sudo unbound-control {} stats'.format(config_path_arg)
+        else:
+            cmd = 'unbound-control {} stats'.format(config_path_arg)
 
         return cmd
 
-    def get_stats(self):
-        cmd = self.get_cmd()
+    def get_stats(self, instance={}):
+        cmd = self.get_cmd(instance.get('unbound_config_path'))
 
         try:
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
@@ -163,7 +168,7 @@ class UnboundCheck(AgentCheck):
             self.count(ns_metric, float(stat), tags)
 
     def check(self, instance):
-        stats = self.get_stats()
+        stats = self.get_stats(instance)
 
         if stats is None:
             return

--- a/checks.d/unbound.py
+++ b/checks.d/unbound.py
@@ -130,7 +130,7 @@ class UnboundCheck(AgentCheck):
         return output
 
 
-    def parse_stat(self, stat):
+    def parse_stat(self, stat, extra_tags=[]):
         label, stat = stat.split("=")
         prefix, suffix = label.split(".", 1)
 
@@ -160,6 +160,10 @@ class UnboundCheck(AgentCheck):
             return
 
         ns_metric = "unbound.{}".format(metric)
+
+        for extra_tag in extra_tags:
+            tags.append(extra_tag)
+
         if metric in self.rate_metrics:
             self.rate(ns_metric, float(stat), tags)
         elif metric in self.gauge_metrics:
@@ -174,10 +178,12 @@ class UnboundCheck(AgentCheck):
             return
 
         try:
+            extra_tags = instance.get('extra_tags', [])
+
             for line in stats.split("\n"):
                 if not line:
                     continue
-                self.parse_stat(line)
+                self.parse_stat(line, extra_tags)
         except Exception as e:
             self.service_check(
                 self.SERVICE_CHECK_NAME,

--- a/tests/checks/integration/test_unbound.py
+++ b/tests/checks/integration/test_unbound.py
@@ -152,3 +152,24 @@ class TestFileUnit(AgentCheckTest):
             self.assertEqual(check_output_mock.call_count, 2)
             check_output_mock.assert_any_call("unbound-control -c unbound1.conf stats", stderr=mock.ANY, shell=mock.ANY)
             check_output_mock.assert_any_call("unbound-control -c unbound2.conf stats", stderr=mock.ANY, shell=mock.ANY)
+
+    def test_additional_tags(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {
+                    'extra_tags': ['tag_name1:tag_value1', 'tag_name2:tag_value2']
+                }
+            ]
+        }
+
+        filename = path.join(self.FIXTURE_PATH, 'stats.txt')
+
+        def get_stats(instance):
+            with open(filename, "r") as fh:
+                return fh.read()
+
+        # Run twice to establish rates.
+        self.run_check(conf, mocks={'get_stats': get_stats})
+
+        self.assertMetric("unbound.recursion.time.avg", value=122.983901, tags=['thread:0', 'tag_name1:tag_value1', 'tag_name2:tag_value2'])


### PR DESCRIPTION
This PR adds the ability to collect metrics from multiple instances of Unbound running on the same host by specifying the Unbound config path in the datadog check configuration (see tests for examples). It also adds the ability to add additional tags to all metrics to help distinguish between the different instances.