### PR TITLE
Enable build egress proxying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:14.04
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
-RUN apt-get update && apt-get install -y build-essential python-dev python-pip python-virtualenv curl
+RUN apt-get update && apt-get install -y build-essential python-dev python-virtualenv curl
+RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && python /tmp/get-pip.py && pip --version
 RUN DD_API_KEY='foo' DD_INSTALL_ONLY=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"
 RUN mkdir /src
 ADD requirements.txt requirements-test.txt Makefile /src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:14.04
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
-RUN apt-get update && apt-get install -y build-essential python-dev python-virtualenv curl
+RUN apt-get update && apt-get install -y build-essential python-dev curl
 RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && python /tmp/get-pip.py && pip --version
+RUN pip install virtualenv
 RUN DD_API_KEY='foo' DD_INSTALL_ONLY=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"
 RUN mkdir /src
 ADD requirements.txt requirements-test.txt Makefile /src/

--- a/stripe-build.yaml
+++ b/stripe-build.yaml
@@ -1,0 +1,7 @@
+# See go/stripe-build for more information about customizing this file
+---
+henson_tarball:
+  docker: {}
+network:
+  restrict_network: true
+  http_proxy_report_only: true


### PR DESCRIPTION
This PR forces all network traffic during the Jenkins build to go through a local sidecar proxy on the Jenkins instance. This will allow us to properly route internet-bound traffic through a smokescreen proxy instance and then prevent jenkins workers from talking directly to the internet. See http://go.corp.stripe.com/stripe-build-egress-restriction for more information.

r? @stripe/observability 
cc @areitz-stripe 