### PR TITLE
[NSQ] Fix check for NSQ 1.x.x

### DIFF
--- a/conf.d/nsq.yaml.example
+++ b/conf.d/nsq.yaml.example
@@ -4,6 +4,7 @@
 # include the tag stage:canary. The regex must include at least one symbolic group.
 init_config:
     topic_name_regex: "service-(?P<stage>prod|canary)$"
+    nsqd_major_version: 1
 
 instances:
     # Where your NSQD HTTP Server Lives


### PR DESCRIPTION
Response from the /stats route has been modified for NSQ 1.x.x. This PR removes the deprecated data key.