### PR TITLE
Upgrade container from Trusty to Xenial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
-RUN apt-get update && apt-get install -y build-essential python-dev curl
+RUN apt-get update && apt-get install -y build-essential python-dev curl lsb-release
 RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && python /tmp/get-pip.py && pip --version
 RUN pip install virtualenv
 RUN DD_API_KEY='foo' DD_INSTALL_ONLY=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN apt-get update && apt-get install -y build-essential python-dev curl

--- a/tests/checks/integration/test_kernel.py
+++ b/tests/checks/integration/test_kernel.py
@@ -51,7 +51,7 @@ class TestKernelUnit(AgentCheckTest):
         }
 
         def get_linux_release():
-            return 'trusty'
+            return 'xenial'
 
         def get_kernel_version():
             return '1.2.3.4-generic'
@@ -70,5 +70,5 @@ class TestKernelUnit(AgentCheckTest):
 
         self.assertMetric("linux.kernel", value=1, metric_type='gauge',
                           tags=['kernel:1.2.3.4-generic',
-                                'release:trusty',
+                                'release:xenial',
                                 'grub_default:unknown'])

--- a/tests/checks/integration/test_outdated_packages.py
+++ b/tests/checks/integration/test_outdated_packages.py
@@ -28,7 +28,7 @@ class TestFileUnit(AgentCheckTest):
             'package': 'foo',
             'version': {
                 'precise': '1.0.0',
-                'trusty': '1.0.0',
+                'xenial': '1.0.0',
             },
         })
         self.run_check(self.config)
@@ -47,7 +47,7 @@ class TestFileUnit(AgentCheckTest):
             'package': 'bar',
             'version': {
                 'precise': '1.3.5',
-                'trusty': '1.3.5',
+                'xenial': '1.3.5',
             },
         })
         self.run_check(self.config)
@@ -66,7 +66,7 @@ class TestFileUnit(AgentCheckTest):
             'package': 'foo',
             'version': {
                 'precise': '1.0.0',
-                'trusty': '1.0.0',
+                'xenial': '1.0.0',
             },
         })
         self.run_check(self.config)
@@ -74,7 +74,7 @@ class TestFileUnit(AgentCheckTest):
         self.assertEqual(len(self.service_checks), 0)
         self.assertMetric('package.up_to_date.change', count=0)
 
-    @mock.patch('outdated_packages.OutdatedPackagesCheck.get_lsb_codename', return_value='trusty')
+    @mock.patch('outdated_packages.OutdatedPackagesCheck.get_lsb_codename', return_value='xenial')
     @mock.patch('outdated_packages.OutdatedPackagesCheck.get_package_version', return_value='1.0.0')
     @mock.patch('outdated_packages.OutdatedPackagesCheck.is_package_installed', return_value=True)
     def test_unknown_release(self, *args):
@@ -92,7 +92,7 @@ class TestFileUnit(AgentCheckTest):
             count=1
         )
 
-    @mock.patch('outdated_packages.OutdatedPackagesCheck.get_lsb_codename', return_value='trusty')
+    @mock.patch('outdated_packages.OutdatedPackagesCheck.get_lsb_codename', return_value='xenial')
     @mock.patch('outdated_packages.OutdatedPackagesCheck.get_package_version', return_value='2.0.0')
     @mock.patch('outdated_packages.OutdatedPackagesCheck.is_package_installed', return_value=True)
     def test_correct_release(self, *args):
@@ -100,13 +100,13 @@ class TestFileUnit(AgentCheckTest):
             'package': 'foo',
             'version': {
                 'precise': '1.0.0',
-                'trusty': '3.0.0',
+                'xenial': '3.0.0',
             },
         })
         self.run_check(self.config)
 
         # The check should succeed if we're on Precise, since the expected
-        # version is older than the current one.  It should fail on Trusty,
+        # version is older than the current one.  It should fail on xenial,
         # since we are thus out of date.
         self.assertServiceCheckCritical(
             'package.up_to_date',


### PR DESCRIPTION
This PR upgrades the base image used in this repo's Dockerfile from
a Trusty base to a Xenial base.

I had to install `lsb-release` manually for the tests to pass. I also replaced `trusty` with `xenial` in some test cases (not sure if that was actually necessary).

r? @dougbarth-stripe 